### PR TITLE
ReleaseCommand: stage is taken into account in success message

### DIFF
--- a/packages/Release/src/Command/ReleaseCommand.php
+++ b/packages/Release/src/Command/ReleaseCommand.php
@@ -96,8 +96,10 @@ final class ReleaseCommand extends Command
 
         if ($isDryRun) {
             $this->symfonyStyle->note('Running in dry mode, nothing is changed');
-        } else {
+        } elseif ($stage === null) {
             $this->symfonyStyle->success(sprintf('Version "%s" is now released!', $version->getVersionString()));
+        } else {
+            $this->symfonyStyle->success(sprintf('Stage "%s" is now finished!', $stage));
         }
 
         return ShellCode::SUCCESS;


### PR DESCRIPTION
- the message "Version XY is now released!" is confusing when using stages
- we have the stage "release-candidate" that ends with sending the release-candidate branch for code-review and someone might get a fright when he sees the message telling him that the version is released