### PR TITLE
Use monorepo-builder script from its own bin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "fix-cs": "vendor/bin/ecs check --fix --ansi",
         "phpstan": "vendor/bin/phpstan analyse --ansi  --error-format symplify",
         "rector": "vendor/bin/rector process --dry-run --ansi",
-        "release": "vendor/bin/monorepo-builder release patch --ansi"
+        "release": "bin/monorepo-builder release patch --ansi"
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
as current repo already monorepo-builder, script can be updated to use its own bin.