### PR TITLE
Support disabling packagist.org

### DIFF
--- a/packages-tests/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator/RepositoryPathComposerJsonDecoratorTest.php
+++ b/packages-tests/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator/RepositoryPathComposerJsonDecoratorTest.php
@@ -31,6 +31,9 @@ final class RepositoryPathComposerJsonDecoratorTest extends AbstractComposerJson
                 'type' => 'path',
                 'url' => 'libs/*/',
             ],
+            [
+                'packagist.org' => false,
+            ],
         ],
     ];
 
@@ -71,13 +74,16 @@ final class RepositoryPathComposerJsonDecoratorTest extends AbstractComposerJson
 
         $expectedComposerJson = [
             ComposerJsonSection::REPOSITORIES => [
-                [
+                0 => [
                     'type' => 'artifact',
                     'url' => 'path/to/directory/with/zips/',
                 ],
-                [
+                1 => [
                     'type' => 'path',
                     'url' => 'libs/*/',
+                ],
+                3 => [
+                    'packagist.org' => false,
                 ],
             ],
         ];

--- a/packages/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
+++ b/packages/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
@@ -28,7 +28,7 @@ final class RepositoryPathComposerJsonDecorator implements ComposerJsonDecorator
         $repositories = $composerJson->getRepositories();
 
         foreach ($repositories as $index => $repository) {
-            if ($repository['type'] !== 'path') {
+            if ($repository['type'] ?? '' !== 'path') {
                 continue;
             }
 
@@ -44,7 +44,7 @@ final class RepositoryPathComposerJsonDecorator implements ComposerJsonDecorator
         $paths = [];
 
         foreach ($repositories as $index => $repository) {
-            if ($repository['type'] !== 'path') {
+            if ($repository['type'] ?? '' !== 'path') {
                 continue;
             }
 

--- a/packages/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
+++ b/packages/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
@@ -28,7 +28,7 @@ final class RepositoryPathComposerJsonDecorator implements ComposerJsonDecorator
         $repositories = $composerJson->getRepositories();
 
         foreach ($repositories as $index => $repository) {
-            if ($repository['type'] ?? '' !== 'path') {
+            if (($repository['type'] ?? '') !== 'path') {
                 continue;
             }
 
@@ -44,7 +44,7 @@ final class RepositoryPathComposerJsonDecorator implements ComposerJsonDecorator
         $paths = [];
 
         foreach ($repositories as $index => $repository) {
-            if ($repository['type'] ?? '' !== 'path') {
+            if (($repository['type'] ?? '') !== 'path') {
                 continue;
             }
 


### PR DESCRIPTION
Type is not a mandatory field of the repository definition.

https://getcomposer.org/doc/05-repositories.md#disabling-packagist-org

You can disable the default Packagist.org repository by adding this to your composer.json:

```
{
    "repositories": [
        {
            "packagist.org": false
        }
    ]
}
```

You can disable Packagist.org globally by using the global config flag:

```
php composer.phar config -g repo.packagist false
```