### PR TITLE
Bump interdependencies bumped too much

### DIFF
--- a/src/Command/BumpInterdependencyCommand.php
+++ b/src/Command/BumpInterdependencyCommand.php
@@ -57,7 +57,7 @@ final class BumpInterdependencyCommand extends AbstractSymplifyCommand
 
         $this->dependencyUpdater->updateFileInfosWithVendorAndVersion(
             $this->composerJsonProvider->getPackagesComposerFileInfos(),
-            $vendorName,
+            $vendorName . '/',
             $version
         );
 

--- a/src/Command/BumpInterdependencyCommand.php
+++ b/src/Command/BumpInterdependencyCommand.php
@@ -57,7 +57,7 @@ final class BumpInterdependencyCommand extends AbstractSymplifyCommand
 
         $this->dependencyUpdater->updateFileInfosWithVendorAndVersion(
             $this->composerJsonProvider->getPackagesComposerFileInfos(),
-            $vendorName . '/',
+            $vendorName,
             $version
         );
 

--- a/src/DependencyUpdater.php
+++ b/src/DependencyUpdater.php
@@ -109,7 +109,7 @@ final class DependencyUpdater
         string $packageName,
         string $packageVersion
     ): bool {
-        if (! \str_starts_with($packageName, $vendor)) {
+        if (! \str_starts_with($packageName, $vendor . '/')) {
             return true;
         }
 

--- a/src/DependencyUpdater.php
+++ b/src/DependencyUpdater.php
@@ -8,6 +8,9 @@ use Symplify\MonorepoBuilder\ComposerJsonManipulator\FileSystem\JsonFileManager;
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
+/**
+ * @see \Symplify\MonorepoBuilder\Tests\DependencyUpdater\DependencyUpdaterTest
+ */
 final class DependencyUpdater
 {
     public function __construct(

--- a/tests/DependencyUpdater/DependencyUpdaterTest.php
+++ b/tests/DependencyUpdater/DependencyUpdaterTest.php
@@ -10,7 +10,7 @@ use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 use Symplify\SmartFileSystem\SmartFileSystem;
 
-class DependencyUpdaterTest extends AbstractKernelTestCase
+final class DependencyUpdaterTest extends AbstractKernelTestCase
 {
     private DependencyUpdater $dependencyUpdater;
 
@@ -29,7 +29,7 @@ class DependencyUpdaterTest extends AbstractKernelTestCase
         $this->smartFileSystem->copy(__DIR__ . '/Source/backup-first.json', __DIR__ . '/Source/first.json');
     }
 
-    public function testUpdateFileInfosWithVendorAndVersion()
+    public function testUpdateFileInfosWithVendorAndVersion(): void
     {
         $fileInfos = [new SmartFileInfo(__DIR__ . '/Source/first.json')];
 

--- a/tests/DependencyUpdater/DependencyUpdaterTest.php
+++ b/tests/DependencyUpdater/DependencyUpdaterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symplify\MonorepoBuilder\Tests\DependencyUpdater;
+
+use Symplify\MonorepoBuilder\DependencyUpdater;
+use Symplify\MonorepoBuilder\Kernel\MonorepoBuilderKernel;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+use Symplify\SmartFileSystem\SmartFileSystem;
+
+class DependencyUpdaterTest extends AbstractKernelTestCase
+{
+    private DependencyUpdater $dependencyUpdater;
+
+    private SmartFileSystem $smartFileSystem;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(MonorepoBuilderKernel::class);
+
+        $this->dependencyUpdater =  $this->getService(DependencyUpdater::class);
+        $this->smartFileSystem = $this->getService(SmartFileSystem::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->smartFileSystem->copy(__DIR__ . '/Source/backup-first.json', __DIR__ . '/Source/first.json');
+    }
+    public function testUpdateFileInfosWithVendorAndVersion()
+    {
+        $fileInfos = [new SmartFileInfo(__DIR__ . '/Source/first.json')];
+
+        $this->dependencyUpdater->updateFileInfosWithVendorAndVersion($fileInfos, 'ex', '5.0-dev');
+
+        $this->assertFileEquals(__DIR__ . '/Source/expected-first.json', __DIR__ . '/Source/first.json');
+    }
+}

--- a/tests/DependencyUpdater/DependencyUpdaterTest.php
+++ b/tests/DependencyUpdater/DependencyUpdaterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Symplify\MonorepoBuilder\Tests\DependencyUpdater;
 
 use Symplify\MonorepoBuilder\DependencyUpdater;
@@ -26,6 +28,7 @@ class DependencyUpdaterTest extends AbstractKernelTestCase
     {
         $this->smartFileSystem->copy(__DIR__ . '/Source/backup-first.json', __DIR__ . '/Source/first.json');
     }
+
     public function testUpdateFileInfosWithVendorAndVersion()
     {
         $fileInfos = [new SmartFileInfo(__DIR__ . '/Source/first.json')];

--- a/tests/DependencyUpdater/Source/backup-first.json
+++ b/tests/DependencyUpdater/Source/backup-first.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "ex/package-one": "4.0-dev",
+        "ex/package-two": "4.0-dev",
+        "example/package-one": "4.0-dev"
+    },
+    "require-dev": {
+        "ex/package-one": "4.0-dev",
+        "ex/package-two": "4.0-dev",
+        "example/package-one": "4.0-dev"
+    }
+}

--- a/tests/DependencyUpdater/Source/expected-first.json
+++ b/tests/DependencyUpdater/Source/expected-first.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "ex/package-one": "5.0-dev",
+        "ex/package-two": "5.0-dev",
+        "example/package-one": "4.0-dev"
+    },
+    "require-dev": {
+        "ex/package-one": "5.0-dev",
+        "ex/package-two": "5.0-dev",
+        "example/package-one": "4.0-dev"
+    }
+}

--- a/tests/DependencyUpdater/Source/first.json
+++ b/tests/DependencyUpdater/Source/first.json
@@ -1,0 +1,12 @@
+{
+    "require": {
+        "ex/package-one": "4.0-dev",
+        "ex/package-two": "4.0-dev",
+        "example/package-one": "4.0-dev"
+    },
+    "require-dev": {
+        "ex/package-one": "4.0-dev",
+        "ex/package-two": "4.0-dev",
+        "example/package-one": "4.0-dev"
+    }
+}


### PR DESCRIPTION
This method upgrades interdependencies for packages that have the same vendor prefix as the root project. But it also upgrades interdependencies for packages that have a vendor prefix that starts with your vendor prefix.

In other words, if your vendor prefix is "ex" and your packages are called "ex/package-test", then it would also bump "example/package-other". This is because it matches "starts with ex".
Instead it should start with "ex/" to match the full vendor name plus the separator. That way it does not include other vendors that start with the same prefix as you as part of their name.