### PR TITLE
Support custom path normalizers and include one for composer patches

### DIFF
--- a/packages-tests/Merge/Package/PackageComposerJsonMergerSource/expected-with-composer-patches.json
+++ b/packages-tests/Merge/Package/PackageComposerJsonMergerSource/expected-with-composer-patches.json
@@ -1,0 +1,16 @@
+{
+    "extra": {
+        "patches": {
+            "example/package-one": [
+                "packages-tests/Merge/Package/SourceComposerPatches/patch-files/example.patch"
+            ],
+            "example/package-two": {
+                "Patch description": "packages-tests/Merge/Package/SourceComposerPatches/patch-files/example.patch",
+                "Patch two description": "packages-tests/Merge/Package/SourceComposerPatches/patch-files/example.patch"
+            },
+            "symfony/dependency-injection": [
+                "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch"
+            ]
+        }
+    }
+}

--- a/packages-tests/Merge/Package/PackageComposerJsonMergerTest.php
+++ b/packages-tests/Merge/Package/PackageComposerJsonMergerTest.php
@@ -25,4 +25,11 @@ final class PackageComposerJsonMergerTest extends AbstractMergeTestCase
 
         $this->doTestDirectoryMergeToFile(__DIR__ . '/SourceUniqueRepositories', $expectedComposerJson);
     }
+
+    public function testComposerPatches(): void
+    {
+        $expectedComposerJson = $this->createComposerJson(__DIR__ . '/PackageComposerJsonMergerSource/expected-with-composer-patches.json');
+
+        $this->doTestDirectoryMergeToFile(__DIR__ . '/SourceComposerPatches', $expectedComposerJson);
+    }
 }

--- a/packages-tests/Merge/Package/SourceComposerPatches/package-one.json
+++ b/packages-tests/Merge/Package/SourceComposerPatches/package-one.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "patches": {
+            "symfony/dependency-injection": [
+                "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch"
+            ]
+        }
+    }
+}

--- a/packages-tests/Merge/Package/SourceComposerPatches/package-three.json
+++ b/packages-tests/Merge/Package/SourceComposerPatches/package-three.json
@@ -1,0 +1,9 @@
+{
+    "extra": {
+        "patches": {
+            "symfony/dependency-injection": [
+                "https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch"
+            ]
+        }
+    }
+}

--- a/packages-tests/Merge/Package/SourceComposerPatches/package-two.json
+++ b/packages-tests/Merge/Package/SourceComposerPatches/package-two.json
@@ -1,0 +1,13 @@
+{
+    "extra": {
+        "patches": {
+            "example/package-one": [
+                "vendor/symplify/monorepo-builder/patch-files/example.patch"
+            ],
+            "example/package-two": {
+                "Patch description": "vendor/symplify/monorepo-builder/patch-files/example.patch",
+                "Patch two description": "./vendor/symplify/monorepo-builder/patch-files/example.patch"
+            }
+        }
+    }
+}

--- a/packages-tests/Merge/PathResolver/AutoloadPathNormalizerTest.php
+++ b/packages-tests/Merge/PathResolver/AutoloadPathNormalizerTest.php
@@ -28,7 +28,7 @@ final class AutoloadPathNormalizerTest extends AbstractComposerJsonDecoratorTest
         $autoloadFileInfo = new SmartFileInfo(__DIR__ . '/AutoloadPathNormalizerSource/autoload.json');
         $composerJson = $this->createComposerJson($autoloadFileInfo);
 
-        $this->autoloadPathNormalizer->normalizeAutoloadPaths($composerJson, $autoloadFileInfo);
+        $this->autoloadPathNormalizer->normalizePaths($composerJson, $autoloadFileInfo);
         $this->assertComposerJsonEquals(
             __DIR__ . '/AutoloadPathNormalizerSource/expected-autoload.json',
             $composerJson

--- a/packages-tests/Merge/PathResolver/ComposerPatchesPathNormalizerTest.php
+++ b/packages-tests/Merge/PathResolver/ComposerPatchesPathNormalizerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Merge\PathResolver;
+
+use Symplify\MonorepoBuilder\Merge\PathResolver\ComposerPatchesPathNormalizer;
+use Symplify\MonorepoBuilder\Tests\Merge\ComposerJsonDecorator\AbstractComposerJsonDecoratorTest;
+
+final class ComposerPatchesPathNormalizerTest extends AbstractComposerJsonDecoratorTest
+{
+    private ComposerPatchesPathNormalizer $composerPatchesPathNormalizer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->composerPatchesPathNormalizer = $this->getService(ComposerPatchesPathNormalizer::class);
+    }
+
+    public function test(): void
+    {
+        if (! defined('SYMPLIFY_MONOREPO')) {
+            $this->markTestSkipped('Already tested on monorepo');
+        }
+    }
+}

--- a/packages/Merge/ComposerJsonMerger.php
+++ b/packages/Merge/ComposerJsonMerger.php
@@ -7,8 +7,8 @@ namespace Symplify\MonorepoBuilder\Merge;
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ComposerJsonFactory;
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\MonorepoBuilder\Merge\Configuration\MergedPackagesCollector;
+use Symplify\MonorepoBuilder\Merge\Contract\ComposerPathNormalizerInterface;
 use Symplify\MonorepoBuilder\Merge\Contract\ComposerKeyMergerInterface;
-use Symplify\MonorepoBuilder\Merge\PathResolver\AutoloadPathNormalizer;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
@@ -18,12 +18,13 @@ final class ComposerJsonMerger
 {
     /**
      * @param ComposerKeyMergerInterface[] $composerKeyMergers
+     * @param ComposerPathNormalizerInterface[] $composerPathNormalizers
      */
     public function __construct(
         private ComposerJsonFactory $composerJsonFactory,
         private MergedPackagesCollector $mergedPackagesCollector,
-        private AutoloadPathNormalizer $autoloadPathNormalizer,
-        private array $composerKeyMergers
+        private array $composerKeyMergers,
+        private array $composerPathNormalizers
     ) {
     }
 
@@ -65,7 +66,9 @@ final class ComposerJsonMerger
         SmartFileInfo $packageFileInfo
     ): void {
         // prepare paths before autolaod merging
-        $this->autoloadPathNormalizer->normalizeAutoloadPaths($newComposerJson, $packageFileInfo);
+        foreach ($this->composerPathNormalizers as $composerPathNormalizer) {
+            $composerPathNormalizer->normalizePaths($newComposerJson, $packageFileInfo);
+        }
         $this->mergeJsonToRoot($mainComposerJson, $newComposerJson);
     }
 }

--- a/packages/Merge/Contract/ComposerPathNormalizerInterface.php
+++ b/packages/Merge/Contract/ComposerPathNormalizerInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Merge\Contract;
+
+use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+interface ComposerPathNormalizerInterface
+{
+    public function normalizePaths(ComposerJson $packageComposerJson, SmartFileInfo $packageFile): void;
+}

--- a/packages/Merge/PathResolver/AutoloadPathNormalizer.php
+++ b/packages/Merge/PathResolver/AutoloadPathNormalizer.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Merge\PathResolver;
 
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Merge\Contract\ComposerPathNormalizerInterface;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
 /**
- * @see \Symplify\MonorepoBuilder\Tests\Merge\PathResolver\AutoloadPathNormalizerTest
+ * @see \Symplify\MonorepoBuilder\Tests\Merge\Package\PackageComposerJsonMergerTest
  */
-final class AutoloadPathNormalizer
+final class AutoloadPathNormalizer implements ComposerPathNormalizerInterface
 {
     /**
      * @var string[]
@@ -22,7 +23,7 @@ final class AutoloadPathNormalizer
      *
      * @see https://github.com/symplify/symplify/issues/1333
      */
-    public function normalizeAutoloadPaths(ComposerJson $packageComposerJson, SmartFileInfo $packageFile): void
+    public function normalizePaths(ComposerJson $packageComposerJson, SmartFileInfo $packageFile): void
     {
         $autoload = $this->normalizeAutoloadArray($packageFile, $packageComposerJson->getAutoload());
         $packageComposerJson->setAutoload($autoload);

--- a/packages/Merge/PathResolver/ComposerPatchesPathNormalizer.php
+++ b/packages/Merge/PathResolver/ComposerPatchesPathNormalizer.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Merge\PathResolver;
+
+use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Merge\Contract\ComposerPathNormalizerInterface;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @see \Symplify\MonorepoBuilder\Tests\Merge\Package\PackageComposerJsonMergerTest
+ */
+final class ComposerPatchesPathNormalizer implements ComposerPathNormalizerInterface
+{
+    /**
+     * @var string[]
+     */
+    private const SECTIONS_WITH_PATH = ['patches'];
+
+    /**
+     *
+     */
+    public function normalizePaths(ComposerJson $packageComposerJson, SmartFileInfo $packageFile): void
+    {
+        $extra = $this->normalizeExtraArray($packageFile, $packageComposerJson->getExtra());
+        $packageComposerJson->setExtra($extra);
+    }
+
+    /**
+     * @param array<string, mixed> $extraArray
+     * @return array<string, mixed>
+     */
+    private function normalizeExtraArray(SmartFileInfo $packageFile, array $extraArray): array
+    {
+        foreach (self::SECTIONS_WITH_PATH as $sectionWithPath) {
+            if (! isset($extraArray[$sectionWithPath])) {
+                continue;
+            }
+
+            $extraArray[$sectionWithPath] = $this->relativizePath($extraArray[$sectionWithPath], $packageFile);
+        }
+
+        return $extraArray;
+    }
+
+    /**
+     * @param mixed[] $patchesSubSection
+     * @return mixed[]
+     */
+    private function relativizePath(array $patchesSubSection, SmartFileInfo $packageFileInfo): array
+    {
+        $packageRelativeDirectory = dirname($packageFileInfo->getRelativeFilePathFromDirectory(getcwd()));
+
+        foreach ($patchesSubSection as $key => $value) {
+            if (is_array($value)) {
+                $patchesSubSection[$key] = array_map(
+                    fn ($path): string => $this->relativizeSinglePath($packageRelativeDirectory, $path),
+                    $value
+                );
+            }
+        }
+
+        return $patchesSubSection;
+    }
+
+    private function relativizeSinglePath(string $packageRelativeDirectory, string $path): string
+    {
+        if (\str_starts_with($path, 'vendor/') || \str_starts_with($path, './vendor/')) {
+            return preg_replace('#^(\./)?vendor/[^/]+/[^/]+#', $packageRelativeDirectory, $path);
+        }
+
+        return $path;
+    }
+}


### PR DESCRIPTION
Currently there is only one path normalizer that changes paths relative to a package to paths relative to the project.
That normalizer is for path-type repositories.
There are more cases where a path needs to be normalized. For instance, in the case of cweagans/composer-patches that are hosted as a file inside a dependency. Or in the case of a `magento2-component` as described in https://devdocs.magento.com/guides/v2.3/extension-dev-guide/package/package_module.html, which has an `{"extra": {"map":{"copy/from":"copy/to"}}}` style content.

I would like developers to be able to add their own path normalizers for this, and I have already included a normalizer for composer patches as they are so widely used.