### PR TITLE
fix: Fixes #24 - Always prepend default config files

### DIFF
--- a/src/Kernel/MonorepoBuilderKernel.php
+++ b/src/Kernel/MonorepoBuilderKernel.php
@@ -18,13 +18,11 @@ final class MonorepoBuilderKernel extends AbstractSymplifyKernel
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
         // Always prepend default config files
-        $configFiles = array_merge(
-            [
-                ConsoleColorDiffConfig::FILE_PATH,
-                __DIR__ . '/../../config/config.php',
-            ],
-            $configFiles,
-        );
+        $configFiles = [
+            ConsoleColorDiffConfig::FILE_PATH,
+            __DIR__ . '/../../config/config.php',
+            ...$configFiles,
+        ];
 
         $autowireInterfacesCompilerPass = new AutowireInterfacesCompilerPass([ReleaseWorkerInterface::class]);
         $compilerPasses = [$autowireInterfacesCompilerPass];

--- a/src/Kernel/MonorepoBuilderKernel.php
+++ b/src/Kernel/MonorepoBuilderKernel.php
@@ -17,8 +17,14 @@ final class MonorepoBuilderKernel extends AbstractSymplifyKernel
      */
     public function createFromConfigs(array $configFiles): ContainerInterface
     {
-        $configFiles[] = __DIR__ . '/../../config/config.php';
-        $configFiles[] = ConsoleColorDiffConfig::FILE_PATH;
+        // Always prepend default config files
+        $configFiles = array_merge(
+            [
+                ConsoleColorDiffConfig::FILE_PATH,
+                __DIR__ . '/../../config/config.php',
+            ],
+            $configFiles,
+        );
 
         $autowireInterfacesCompilerPass = new AutowireInterfacesCompilerPass([ReleaseWorkerInterface::class]);
         $compilerPasses = [$autowireInterfacesCompilerPass];


### PR DESCRIPTION
This should be back-ported on `v11`, as I saw that next version will only support PHP v8.1.

The same update should be done on https://github.com/symplify/symplify-kernel/blob/main/src/HttpKernel/AbstractSymplifyKernel.php