### PR TITLE
Prevent release on wrong branch

### DIFF
--- a/packages/Release/Command/ReleaseCommand.php
+++ b/packages/Release/Command/ReleaseCommand.php
@@ -81,6 +81,13 @@ final class ReleaseCommand extends AbstractSymplifyCommand
             $this->releaseWorkerReporter->printMetadata($releaseWorker);
 
             if (! $isDryRun) {
+                if (method_exists($releaseWorker,'shouldConfirm')
+                    && $releaseWorker->shouldConfirm()['whenTrue']()
+                    && ! $this->symfonyStyle->confirm($releaseWorker->shouldConfirm()['message'])
+                ){
+                        return self::FAILURE;
+                }
+
                 $releaseWorker->work($version);
             }
         }

--- a/packages/Release/ReleaseWorker/TagVersionReleaseWorker.php
+++ b/packages/Release/ReleaseWorker/TagVersionReleaseWorker.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Release\ReleaseWorker;
 
 use PharIo\Version\Version;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
 use Symplify\MonorepoBuilder\ValueObject\Option;

--- a/packages/Release/ReleaseWorker/TagVersionReleaseWorker.php
+++ b/packages/Release/ReleaseWorker/TagVersionReleaseWorker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Release\ReleaseWorker;
 
 use PharIo\Version\Version;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\Release\Process\ProcessRunner;
 use Symplify\MonorepoBuilder\ValueObject\Option;
@@ -20,6 +21,17 @@ final class TagVersionReleaseWorker implements ReleaseWorkerInterface
         ParameterProvider $parameterProvider
     ) {
         $this->branchName = $parameterProvider->provideStringParameter(Option::DEFAULT_BRANCH_NAME);
+    }
+
+    /**
+     * @return array<string,callable(): bool|string>
+     */
+    public function shouldConfirm(): array
+    {
+        return [
+            'whenTrue' => fn(): bool => self::getCurrentBranch() !== self::getDefaultBranch(),
+            'message'=> sprintf('Do you want to release it on the [ %s ] branch?',self::getCurrentBranch())
+        ];
     }
 
     public function work(Version $version): void
@@ -41,5 +53,19 @@ final class TagVersionReleaseWorker implements ReleaseWorkerInterface
     public function getDescription(Version $version): string
     {
         return sprintf('Add local tag "%s"', $version->getOriginalString());
+    }
+
+    private function getCurrentBranch(): string
+    {
+        exec('git rev-parse --abbrev-ref HEAD',$outputs);
+
+        return $outputs[0];
+    }
+
+    private function getDefaultBranch(): string
+    {
+        exec("git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'",$outputs);
+
+        return $outputs[0];
     }
 }


### PR DESCRIPTION
When executing the release, if the current branch is not the same as the default branch, user confirmation is required before proceeding

Like this:
<img width="1100" alt="image" src="https://github.com/symplify/monorepo-builder/assets/29700073/31b3afce-08f7-45ae-afc8-d151a8243ee2">
