### PR TITLE
Fix get default branch failed when Git has not set trace branch

### DIFF
--- a/packages/Release/ReleaseWorker/TagVersionReleaseWorker.php
+++ b/packages/Release/ReleaseWorker/TagVersionReleaseWorker.php
@@ -28,7 +28,7 @@ final class TagVersionReleaseWorker implements ReleaseWorkerInterface
     public function shouldConfirm(): array
     {
         return [
-            'whenTrue' => fn(): bool => self::getDefaultBranch() !== null && self::getCurrentBranch() !== self::getDefaultBranch(),
+            'whenTrue' => static fn(): bool => self::getDefaultBranch() !== null && self::getCurrentBranch() !== self::getDefaultBranch(),
             'message'=> sprintf('Do you want to release it on the [ %s ] branch?',self::getCurrentBranch())
         ];
     }
@@ -63,8 +63,9 @@ final class TagVersionReleaseWorker implements ReleaseWorkerInterface
 
     private function getDefaultBranch(): ?string
     {
-        exec("git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'",$outputs,$result_code);
+        exec('git remote set-head origin -a');
+        exec("git symbolic-ref --short refs/remotes/origin/HEAD | cut -d '/' -f 2",$outputs,$result_code);
 
-        return $result_code === 0 ? $outputs[0] : null;
+        return $result_code === 0 ? $outputs[0] ?? null : null;
     }
 }


### PR DESCRIPTION
This pull request solved get the default branch failed  when Git's tracking branch has not been explicitly set.

Prior to this fix, the method `getDefaultBranch()` would fail in instances where a tracking branch was not properly setup in Git, and as a result, retrieving the default branch would not be possible.

Now, I will execute the command that `git remote set-head origin -a` to set the tracking branch to avoid the error reproduced