### PR TITLE
Resolve the `symfony/config` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,9 @@
             ]
         }
     },
+    "conflict": {
+        "symfony/config": ">=6.3.0"
+    },
     "config": {
         "platform-check": false,
         "allow-plugins": {


### PR DESCRIPTION
The `symfony/config` package uses the `Stringable` interface, a feature introduced in PHP 8.0. Since Rector cannot downgrade this feature, we are locking the version to 6.3