### PR TITLE
fix: remove early exit from autoload path loading

### DIFF
--- a/bin/monorepo-builder.php
+++ b/bin/monorepo-builder.php
@@ -25,7 +25,6 @@ $possibleAutoloadPaths = [
 foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {
     if (file_exists($possibleAutoloadPath)) {
         require_once $possibleAutoloadPath;
-        break;
     }
 }
 


### PR DESCRIPTION
When you create a custom worker, the monorepo-builder command is not loading it properly. The early return when requiring the autloader does not load your custom classes.

Closes #33.