### PR TITLE
Fix composer install

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -42,7 +42,13 @@ jobs:
 
           -
             name: 'Check Active Classes'
-            run: vendor/bin/class-leak check src packages bin --ansi  --skip-type="Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface" --skip-type="\Symplify\MonorepoBuilder\Merge\Contract\ComposerKeyMergerInterface" --skip-type="\Symplify\MonorepoBuilder\Merge\Contract\ComposerJsonDecoratorInterface"
+            run: >
+              vendor/bin/class-leak check src packages bin --ansi
+              --skip-type="Symplify\\MonorepoBuilder\\Merge\\Contract\\ComposerJsonDecoratorInterface"
+              --skip-type="Symplify\\MonorepoBuilder\\Merge\\Contract\\ComposerKeyMergerInterface"
+              --skip-type="Symplify\\MonorepoBuilder\\Merge\\PathResolver\\AutoloadPathNormalizer"
+              --skip-type="Symplify\\MonorepoBuilder\\Merge\\PathResolver\\ComposerPatchesPathNormalizer"
+              --skip-type="Symplify\\MonorepoBuilder\\Release\\Contract\\ReleaseWorker\\ReleaseWorkerInterface"
 
     name: ${{ matrix.actions.name }}
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -3,64 +3,50 @@
     "description": "Not only Composer tools to build a Monorepo.",
     "license": "MIT",
     "bin": [
-        "bin/monorepo-builder"
+        "bin/monorepo-builder",
+        "src-deps/easy-testing/bin/easy-testing"
     ],
     "require": {
         "php": ">=8.1",
         "nette/utils": "^4.0.5",
         "phar-io/version": "^3.2",
-        "symfony/finder": "^6.2",
-        "symfony/dependency-injection": "^6.2",
+        "sebastian/diff": "^5.0",
+        "symfony/config": "^6.2",
         "symfony/console": "^6.2",
+        "symfony/dependency-injection": "^6.2",
+        "symfony/filesystem": "^6.2",
+        "symfony/finder": "^6.2",
+        "symfony/http-kernel": "^6.2",
         "symfony/process": "^6.2",
-        "symplify/package-builder": "*",
-        "symplify/symplify-kernel": "*"
+        "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.3.1",
         "cweagans/composer-patches": "^1.7",
-        "rector/rector": "^0.17",
-        "phpstan/phpstan": "^1.10",
-        "symplify/easy-coding-standard": "^12.0",
-        "symplify/easy-ci": "^11.3",
-        "symplify/phpstan-extensions": "^11.1",
         "phpstan/extension-installer": "^1.2",
+        "phpstan/phpstan": "^1.10",
+        "phpunit/phpunit": "^10.3.1",
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "tracy/tracy": "^2.9",
-        "tomasvotruba/class-leak": "0.1.1.72"
+        "rector/rector": "^0.17",
+        "symplify/easy-ci": "^11.3",
+        "symplify/easy-coding-standard": "^12.0",
+        "symplify/phpstan-extensions": "^11.1",
+        "symplify/phpstan-rules": "^11.2",
+        "tomasvotruba/class-leak": "^2.0.5",
+        "tomasvotruba/unused-public": "^0.3.0",
+        "tracy/tracy": "^2.9"
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "src-deps/autowire-array-parameter"
-        },
-        {
-            "type": "path",
-            "url": "src-deps/composer-json-manipulator"
-        },
-        {
-            "type": "path",
-            "url": "src-deps/easy-testing"
-        },
-        {
-            "type": "path",
-            "url": "src-deps/package-builder"
-        },
-        {
-            "type": "path",
-            "url": "src-deps/smart-file-system"
-        },
-        {
-            "type": "path",
-            "url": "src-deps/symplify-kernel"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "Symplify\\MonorepoBuilder\\": [
                 "src",
                 "packages"
-            ]
+            ],
+            "Symplify\\AutowireArrayParameter\\": "src-deps/autowire-array-parameter/src",
+            "Symplify\\ComposerJsonManipulator\\": "src-deps/composer-json-manipulator/src",
+            "Symplify\\EasyTesting\\": "src-deps/easy-testing/src",
+            "Symplify\\PackageBuilder\\": "src-deps/package-builder/src",
+            "Symplify\\SmartFileSystem\\": "src-deps/smart-file-system/src",
+            "Symplify\\SymplifyKernel\\": "src-deps/symplify-kernel/src"
         }
     },
     "autoload-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,6 @@ parameters:
         - src
         - config
         - tests
+
+    unused_public:
+        methods: false


### PR DESCRIPTION
After my last PR was merged, I tried upgrading the package on one of my projects and found that the install is broken. This should fix it.

What changed:
- Instead of loading subpackages as separate packages with filesystem repo paths, I stripped all that out and added PSR-4 class maps to load them as equal parts of this project.