### PR TITLE
Fix: bumping interdependency only for packages instead of all vendor packages

### DIFF
--- a/src/Command/BumpInterdependencyCommand.php
+++ b/src/Command/BumpInterdependencyCommand.php
@@ -11,7 +11,6 @@ use Symplify\MonorepoBuilder\DependencyUpdater;
 use Symplify\MonorepoBuilder\FileSystem\ComposerJsonProvider;
 use Symplify\MonorepoBuilder\Validator\SourcesPresenceValidator;
 use Symplify\PackageBuilder\Console\Command\AbstractSymplifyCommand;
-use Symplify\SymplifyKernel\Exception\ShouldNotHappenException;
 
 final class BumpInterdependencyCommand extends AbstractSymplifyCommand
 {
@@ -46,18 +45,11 @@ final class BumpInterdependencyCommand extends AbstractSymplifyCommand
         /** @var string $version */
         $version = $input->getArgument(self::VERSION_ARGUMENT);
 
-        $rootComposerJson = $this->composerJsonProvider->getRootComposerJson();
+        $packageNames = $this->composerJsonProvider->getPackageNames();
 
-        // @todo resolve better for only found packages
-        // see https://github.com/symplify/symplify/pull/1037/files
-        $vendorName = $rootComposerJson->getVendorName();
-        if ($vendorName === null) {
-            throw new ShouldNotHappenException();
-        }
-
-        $this->dependencyUpdater->updateFileInfosWithVendorAndVersion(
+        $this->dependencyUpdater->updateFileInfosWithPackagesAndVersion(
             $this->composerJsonProvider->getPackagesComposerFileInfos(),
-            $vendorName,
+            $packageNames,
             $version
         );
 


### PR DESCRIPTION
Bumping interdependency should only be done for monorepo packages, not for everything with the same vendor name.

Problem

Current implementation of the command updated interdependency for all dependencies with the same vendor name. However, there are scenarios when there are dependencies with the same vendor name, but not part of the monorepo. 

Solution

Bump interdepencies only for packages of the monorepo.