### PR TITLE
Fix disableDefaultWorkers() edge case 

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -55,10 +55,13 @@ return static function (MBConfig $mbConfig): void {
             __DIR__ . '/../packages/Release/ReleaseWorker',
         ]);
 
-    // Always register default workers here. They will be removed by
-    // RemoveDefaultWorkersCompilerPass if user called disableDefaultWorkers()
-    $services->set(TagVersionReleaseWorker::class);
-    $services->set(PushTagReleaseWorker::class);
+    // Register default workers with a special tag to identify them.
+    // RemoveDefaultWorkersCompilerPass will remove services with this tag
+    // if user called disableDefaultWorkers(), but preserve user-registered workers.
+    $services->set(TagVersionReleaseWorker::class)
+        ->tag('monorepo.default_worker');
+    $services->set(PushTagReleaseWorker::class)
+        ->tag('monorepo.default_worker');
 
     $services->load('Symplify\MonorepoBuilder\\', __DIR__ . '/../src')
         ->exclude([

--- a/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
+++ b/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Kernel\MonorepoBuilderKernel;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+
+/**
+ * Tests for MBConfig::disableDefaultWorkers() functionality.
+ *
+ * @see https://github.com/symplify/monorepo-builder/issues/95
+ */
+final class DisableDefaultWorkersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Reset static state before each test
+        $this->resetMBConfigState();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up static state after each test
+        $this->resetMBConfigState();
+    }
+
+    /**
+     * Scenario 1: Default behavior - workers should be registered
+     */
+    public function testDefaultWorkersAreRegisteredByDefault(): void
+    {
+        $monorepoBuilderKernel = new MonorepoBuilderKernel();
+        $container = $monorepoBuilderKernel->createFromConfigs([__DIR__ . '/config/default_behavior.php']);
+
+        $this->assertTrue($container->has(TagVersionReleaseWorker::class));
+        $this->assertTrue($container->has(PushTagReleaseWorker::class));
+    }
+
+    /**
+     * Scenario 2: disableDefaultWorkers() removes both default workers
+     */
+    public function testDisableDefaultWorkersRemovesBothWorkers(): void
+    {
+        $monorepoBuilderKernel = new MonorepoBuilderKernel();
+        $container = $monorepoBuilderKernel->createFromConfigs([__DIR__ . '/config/disable_default_workers.php']);
+
+        $this->assertFalse($container->has(TagVersionReleaseWorker::class));
+        $this->assertFalse($container->has(PushTagReleaseWorker::class));
+    }
+
+    /**
+     * Scenario 3: disableDefaultWorkers() + manually add worker preserves user's worker
+     */
+    public function testDisableDefaultWorkersPreservesUserAddedWorker(): void
+    {
+        $monorepoBuilderKernel = new MonorepoBuilderKernel();
+        $container = $monorepoBuilderKernel->createFromConfigs([__DIR__ . '/config/disable_and_add_custom.php']);
+
+        // User explicitly added TagVersionReleaseWorker, so it should be preserved
+        $this->assertTrue($container->has(TagVersionReleaseWorker::class));
+        // User did not add PushTagReleaseWorker, so it should be removed
+        $this->assertFalse($container->has(PushTagReleaseWorker::class));
+    }
+
+    private function resetMBConfigState(): void
+    {
+        $reflectionClass = new ReflectionClass(MBConfig::class);
+        $reflectionProperty = $reflectionClass->getProperty('disableDefaultWorkers');
+        $reflectionProperty->setValue(null, false);
+    }
+}

--- a/packages-tests/Release/DisableDefaultWorkers/config/default_behavior.php
+++ b/packages-tests/Release/DisableDefaultWorkers/config/default_behavior.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\MonorepoBuilder\Config\MBConfig;
+
+return static function (MBConfig $mbConfig): void {
+    // Default behavior - don't disable default workers
+    $mbConfig->defaultBranch('main');
+};

--- a/packages-tests/Release/DisableDefaultWorkers/config/disable_and_add_custom.php
+++ b/packages-tests/Release/DisableDefaultWorkers/config/disable_and_add_custom.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+
+return static function (MBConfig $mbConfig): void {
+    // Disable default workers
+    MBConfig::disableDefaultWorkers();
+
+    // But user explicitly wants TagVersionReleaseWorker
+    // This should be preserved because user registration replaces the tagged default
+    $mbConfig->workers([
+        TagVersionReleaseWorker::class,
+    ]);
+};

--- a/packages-tests/Release/DisableDefaultWorkers/config/disable_default_workers.php
+++ b/packages-tests/Release/DisableDefaultWorkers/config/disable_default_workers.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\MonorepoBuilder\Config\MBConfig;
+
+return static function (MBConfig $mbConfig): void {
+    // Disable default workers - both should be removed
+    MBConfig::disableDefaultWorkers();
+};

--- a/src-deps/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
+++ b/src-deps/autowire-array-parameter/src/DependencyInjection/CompilerPass/AutowireArrayParameterCompilerPass.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Symplify\AutowireArrayParameter\DependencyInjection\CompilerPass;
 
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Nette\Utils\Strings;
 use ReflectionClass;
 use ReflectionMethod;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
 use Symplify\AutowireArrayParameter\DependencyInjection\DefinitionFinder;
 use Symplify\AutowireArrayParameter\DocBlock\ParamTypeDocBlockResolver;
 use Symplify\AutowireArrayParameter\Skipper\ParameterSkipper;

--- a/src-deps/autowire-array-parameter/src/Skipper/ParameterSkipper.php
+++ b/src-deps/autowire-array-parameter/src/Skipper/ParameterSkipper.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Symplify\AutowireArrayParameter\Skipper;
 
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
 use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 use ReflectionType;
+use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\ContextProviderInterface;
 use Symplify\AutowireArrayParameter\TypeResolver\ParameterTypeResolver;
 
 final class ParameterSkipper


### PR DESCRIPTION
  Fix disableDefaultWorkers() edge case where user-added workers were incorrectly removed

  Use 'monorepo.default_worker' tag to distinguish between default-registered and
  user-registered workers, allowing users to disable defaults while still manually
  adding the same worker classes.