### PR TITLE
chore: allow webmozart/assert ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "symfony/finder": "^7.0 || ^8.0",
         "symfony/http-kernel": "^7.0 || ^8.0",
         "symfony/process": "^7.0 || ^8.0",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.11 || ^2.0"
     },
     "require-dev": {
         "phpstan/extension-installer": "1.4.3",


### PR DESCRIPTION
After https://github.com/TomasVotruba/unused-public/pull/153 and https://github.com/symplify/phpstan-rules/pull/253 webmozart/assert ^2 can be added to this project