### PR TITLE
Remove stale composer-json-manipulator autoload entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
                 "packages"
             ],
             "Symplify\\AutowireArrayParameter\\": "src-deps/autowire-array-parameter/src",
-            "Symplify\\ComposerJsonManipulator\\": "src-deps/composer-json-manipulator/src",
             "Symplify\\EasyTesting\\": "src-deps/easy-testing/src",
             "Symplify\\PackageBuilder\\": "src-deps/package-builder/src",
             "Symplify\\SmartFileSystem\\": "src-deps/smart-file-system/src",


### PR DESCRIPTION
The src-deps/composer-json-manipulator directory was removed in #108 (code merged into packages/ComposerJsonManipulator under the MonorepoBuilder namespace), but the PSR-4 autoload entry remained in composer.json. 

Box fails during PHAR compilation because it resolves this path and expects the directory to exist.