### PR TITLE
chore: allow sebastian/diff ^8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": ">=8.2",
         "nette/utils": "^4.0.5",
         "phar-io/version": "^3.2",
-        "sebastian/diff": "^6.0 || ^7.0",
+        "sebastian/diff": "^6.0 || ^7.0 || ^8.0",
         "symfony/config": "^7.0 || ^8.0",
         "symfony/console": "^7.0 || ^8.0",
         "symfony/dependency-injection": "^7.0 || ^8.0",


### PR DESCRIPTION
Between version 6,7 and 8 only the minimal required php version change.

- Version 6 : minimal 8.2
- Version 7: minimal 8.3
- Version 8: minimal 8.4