### PR TITLE
Fix workers() not respecting user-specified order

### DIFF
--- a/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
+++ b/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers;
 
+use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symplify\MonorepoBuilder\Config\MBConfig;
@@ -72,7 +73,7 @@ final class DisableDefaultWorkersTest extends TestCase
         /** @var ReleaseWorkerProvider $provider */
         $provider = $container->get(ReleaseWorkerProvider::class);
         $workers = $provider->provideByStage(Stage::MAIN);
-        $workerClasses = array_map(static fn ($w) => $w::class, $workers);
+        $workerClasses = array_map(static fn (ReleaseWorkerInterface $releaseWorker): string => $releaseWorker::class, $workers);
         $this->assertContains(TagVersionReleaseWorker::class, $workerClasses);
     }
 
@@ -87,7 +88,7 @@ final class DisableDefaultWorkersTest extends TestCase
         /** @var ReleaseWorkerProvider $provider */
         $provider = $container->get(ReleaseWorkerProvider::class);
         $workers = $provider->provideByStage(Stage::MAIN);
-        $workerClasses = array_map(static fn ($w) => $w::class, $workers);
+        $workerClasses = array_map(static fn (ReleaseWorkerInterface $releaseWorker): string => $releaseWorker::class, $workers);
 
         // Should have exactly 3 workers, no duplicates
         $this->assertSame([
@@ -111,7 +112,7 @@ final class DisableDefaultWorkersTest extends TestCase
         /** @var ReleaseWorkerProvider $provider */
         $provider = $container->get(ReleaseWorkerProvider::class);
         $workers = $provider->provideByStage(Stage::MAIN);
-        $workerClasses = array_map(static fn ($w) => $w::class, $workers);
+        $workerClasses = array_map(static fn (ReleaseWorkerInterface $releaseWorker): string => $releaseWorker::class, $workers);
 
         $this->assertSame([
             FetchTagsReleaseWorker::class,

--- a/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
+++ b/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
@@ -75,7 +75,28 @@ final class DisableDefaultWorkersTest extends TestCase
     }
 
     /**
-     * Scenario 4: disableDefaultWorkers() + workers() respects user-specified order
+     * Scenario 4: workers() without disableDefaultWorkers() should not duplicate overlapping workers
+     */
+    public function testWorkersWithoutDisableDoesNotDuplicate(): void
+    {
+        $monorepoBuilderKernel = new MonorepoBuilderKernel();
+        $container = $monorepoBuilderKernel->createFromConfigs([__DIR__ . '/config/add_custom_without_disable.php']);
+
+        /** @var ReleaseWorkerProvider $provider */
+        $provider = $container->get(ReleaseWorkerProvider::class);
+        $workers = $provider->provideByStage(Stage::MAIN);
+        $workerClasses = array_map(static fn ($w) => $w::class, $workers);
+
+        // Should have exactly 3 workers, no duplicates
+        $this->assertSame([
+            AddTagToChangelogReleaseWorker::class,
+            TagVersionReleaseWorker::class,
+            PushTagReleaseWorker::class,
+        ], $workerClasses);
+    }
+
+    /**
+     * Scenario 5: disableDefaultWorkers() + workers() respects user-specified order
      *
      * @see https://github.com/symplify/monorepo-builder/issues/111
      */
@@ -99,7 +120,11 @@ final class DisableDefaultWorkersTest extends TestCase
     private function resetMBConfigState(): void
     {
         $reflectionClass = new ReflectionClass(MBConfig::class);
+
         $reflectionProperty = $reflectionClass->getProperty('disableDefaultWorkers');
         $reflectionProperty->setValue(null, false);
+
+        $reflectionProperty = $reflectionClass->getProperty('userWorkerClasses');
+        $reflectionProperty->setValue(null, []);
     }
 }

--- a/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
+++ b/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
@@ -13,6 +13,8 @@ use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorkerProvider;
 use Symplify\MonorepoBuilder\Release\ValueObject\Stage;
+use Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers\Fixture\FetchTagsReleaseWorker;
+use Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers\Fixture\GenerateChangelogReleaseWorker;
 
 /**
  * Tests for MBConfig::disableDefaultWorkers() functionality.
@@ -96,7 +98,8 @@ final class DisableDefaultWorkersTest extends TestCase
     }
 
     /**
-     * Scenario 5: disableDefaultWorkers() + workers() respects user-specified order
+     * Scenario 5: Reproduces the exact scenario from issue #111.
+     * User wants custom workers to run BEFORE the default tag/push workers.
      *
      * @see https://github.com/symplify/monorepo-builder/issues/111
      */
@@ -111,7 +114,8 @@ final class DisableDefaultWorkersTest extends TestCase
         $workerClasses = array_map(static fn ($w) => $w::class, $workers);
 
         $this->assertSame([
-            AddTagToChangelogReleaseWorker::class,
+            FetchTagsReleaseWorker::class,
+            GenerateChangelogReleaseWorker::class,
             TagVersionReleaseWorker::class,
             PushTagReleaseWorker::class,
         ], $workerClasses);

--- a/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
+++ b/packages-tests/Release/DisableDefaultWorkers/DisableDefaultWorkersTest.php
@@ -8,8 +8,11 @@ use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use Symplify\MonorepoBuilder\Config\MBConfig;
 use Symplify\MonorepoBuilder\Kernel\MonorepoBuilderKernel;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorkerProvider;
+use Symplify\MonorepoBuilder\Release\ValueObject\Stage;
 
 /**
  * Tests for MBConfig::disableDefaultWorkers() functionality.
@@ -20,13 +23,11 @@ final class DisableDefaultWorkersTest extends TestCase
 {
     protected function setUp(): void
     {
-        // Reset static state before each test
         $this->resetMBConfigState();
     }
 
     protected function tearDown(): void
     {
-        // Clean up static state after each test
         $this->resetMBConfigState();
     }
 
@@ -62,10 +63,37 @@ final class DisableDefaultWorkersTest extends TestCase
         $monorepoBuilderKernel = new MonorepoBuilderKernel();
         $container = $monorepoBuilderKernel->createFromConfigs([__DIR__ . '/config/disable_and_add_custom.php']);
 
-        // User explicitly added TagVersionReleaseWorker, so it should be preserved
-        $this->assertTrue($container->has(TagVersionReleaseWorker::class));
         // User did not add PushTagReleaseWorker, so it should be removed
         $this->assertFalse($container->has(PushTagReleaseWorker::class));
+
+        // User explicitly added TagVersionReleaseWorker via workers(), so it should be available
+        /** @var ReleaseWorkerProvider $provider */
+        $provider = $container->get(ReleaseWorkerProvider::class);
+        $workers = $provider->provideByStage(Stage::MAIN);
+        $workerClasses = array_map(static fn ($w) => $w::class, $workers);
+        $this->assertContains(TagVersionReleaseWorker::class, $workerClasses);
+    }
+
+    /**
+     * Scenario 4: disableDefaultWorkers() + workers() respects user-specified order
+     *
+     * @see https://github.com/symplify/monorepo-builder/issues/111
+     */
+    public function testWorkerOrderIsRespected(): void
+    {
+        $monorepoBuilderKernel = new MonorepoBuilderKernel();
+        $container = $monorepoBuilderKernel->createFromConfigs([__DIR__ . '/config/disable_and_reorder.php']);
+
+        /** @var ReleaseWorkerProvider $provider */
+        $provider = $container->get(ReleaseWorkerProvider::class);
+        $workers = $provider->provideByStage(Stage::MAIN);
+        $workerClasses = array_map(static fn ($w) => $w::class, $workers);
+
+        $this->assertSame([
+            AddTagToChangelogReleaseWorker::class,
+            TagVersionReleaseWorker::class,
+            PushTagReleaseWorker::class,
+        ], $workerClasses);
     }
 
     private function resetMBConfigState(): void

--- a/packages-tests/Release/DisableDefaultWorkers/Fixture/FetchTagsReleaseWorker.php
+++ b/packages-tests/Release/DisableDefaultWorkers/Fixture/FetchTagsReleaseWorker.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers\Fixture;
+
+use PharIo\Version\Version;
+use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
+
+final readonly class FetchTagsReleaseWorker implements ReleaseWorkerInterface
+{
+    public function work(Version $version): void
+    {
+    }
+
+    public function getDescription(Version $version): string
+    {
+        return 'Fetched remote tags';
+    }
+}

--- a/packages-tests/Release/DisableDefaultWorkers/Fixture/GenerateChangelogReleaseWorker.php
+++ b/packages-tests/Release/DisableDefaultWorkers/Fixture/GenerateChangelogReleaseWorker.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers\Fixture;
+
+use PharIo\Version\Version;
+use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
+
+final readonly class GenerateChangelogReleaseWorker implements ReleaseWorkerInterface
+{
+    public function work(Version $version): void
+    {
+    }
+
+    public function getDescription(Version $version): string
+    {
+        return 'Generate changelog from conventional commits';
+    }
+}

--- a/packages-tests/Release/DisableDefaultWorkers/config/add_custom_without_disable.php
+++ b/packages-tests/Release/DisableDefaultWorkers/config/add_custom_without_disable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+
+return static function (MBConfig $mbConfig): void {
+    // User adds workers without disabling defaults, including overlap with defaults
+    $mbConfig->workers([
+        AddTagToChangelogReleaseWorker::class,
+        TagVersionReleaseWorker::class,
+        PushTagReleaseWorker::class,
+    ]);
+};

--- a/packages-tests/Release/DisableDefaultWorkers/config/disable_and_reorder.php
+++ b/packages-tests/Release/DisableDefaultWorkers/config/disable_and_reorder.php
@@ -3,16 +3,23 @@
 declare(strict_types=1);
 
 use Symplify\MonorepoBuilder\Config\MBConfig;
-use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
 use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+use Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers\Fixture\FetchTagsReleaseWorker;
+use Symplify\MonorepoBuilder\Tests\Release\DisableDefaultWorkers\Fixture\GenerateChangelogReleaseWorker;
 
+/**
+ * Reproduces the exact scenario from issue #111:
+ * User wants custom workers to run BEFORE the default tag/push workers.
+ *
+ * @see https://github.com/symplify/monorepo-builder/issues/111
+ */
 return static function (MBConfig $mbConfig): void {
     MBConfig::disableDefaultWorkers();
 
-    // User wants custom workers to run BEFORE the default ones
     $mbConfig->workers([
-        AddTagToChangelogReleaseWorker::class,
+        FetchTagsReleaseWorker::class,
+        GenerateChangelogReleaseWorker::class,
         TagVersionReleaseWorker::class,
         PushTagReleaseWorker::class,
     ]);

--- a/packages-tests/Release/DisableDefaultWorkers/config/disable_and_reorder.php
+++ b/packages-tests/Release/DisableDefaultWorkers/config/disable_and_reorder.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\AddTagToChangelogReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\PushTagReleaseWorker;
+use Symplify\MonorepoBuilder\Release\ReleaseWorker\TagVersionReleaseWorker;
+
+return static function (MBConfig $mbConfig): void {
+    MBConfig::disableDefaultWorkers();
+
+    // User wants custom workers to run BEFORE the default ones
+    $mbConfig->workers([
+        AddTagToChangelogReleaseWorker::class,
+        TagVersionReleaseWorker::class,
+        PushTagReleaseWorker::class,
+    ]);
+};

--- a/src/Config/MBConfig.php
+++ b/src/Config/MBConfig.php
@@ -14,6 +14,11 @@ final class MBConfig extends ContainerConfigurator
     private static bool $disableDefaultWorkers = false;
 
     /**
+     * @var array<class-string<ReleaseWorkerInterface>>
+     */
+    private static array $userWorkerClasses = [];
+
+    /**
      * @param string[] $packageDirectories
      */
     public function packageDirectories(array $packageDirectories): void
@@ -27,6 +32,14 @@ final class MBConfig extends ContainerConfigurator
     public static function isDisableDefaultWorkers(): bool
     {
         return self::$disableDefaultWorkers;
+    }
+
+    /**
+     * @return array<class-string<ReleaseWorkerInterface>>
+     */
+    public static function getUserWorkerClasses(): array
+    {
+        return self::$userWorkerClasses;
     }
 
     public static function disableDefaultWorkers(): void
@@ -73,6 +86,8 @@ final class MBConfig extends ContainerConfigurator
     public function workers(array $workerClasses): void
     {
         $services = $this->services();
+
+        self::$userWorkerClasses = $workerClasses;
 
         // Use a unique service ID prefix so user-registered workers don't replace
         // default definitions (which would preserve the original array position in

--- a/src/Config/MBConfig.php
+++ b/src/Config/MBConfig.php
@@ -74,8 +74,11 @@ final class MBConfig extends ContainerConfigurator
     {
         $services = $this->services();
 
-        foreach ($workerClasses as $workerClass) {
-            $services->set($workerClass);
+        // Use a unique service ID prefix so user-registered workers don't replace
+        // default definitions (which would preserve the original array position in
+        // the container and break the user's intended ordering).
+        foreach ($workerClasses as $index => $workerClass) {
+            $services->set('user_release_worker.' . $index, $workerClass);
         }
     }
 

--- a/src/DependencyInjection/CompilerPass/RemoveDefaultWorkersCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/RemoveDefaultWorkersCompilerPass.php
@@ -9,15 +9,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symplify\MonorepoBuilder\Config\MBConfig;
 
 /**
- * Removes default release workers from the container if MBConfig::disableDefaultWorkers() was called.
+ * Manages default release workers based on user configuration:
  *
- * This uses a tag-based approach to distinguish between:
- * - Default workers registered by config/config.php (tagged with 'monorepo.default_worker')
- * - User-registered workers (no tag, or re-registered without the tag)
- *
- * When user calls disableDefaultWorkers() and then manually registers a worker
- * (even one with the same class as a default worker), only the tagged default
- * definition is removed, preserving the user's explicit registration.
+ * 1. If disableDefaultWorkers() was called, removes all services tagged with 'monorepo.default_worker'.
+ * 2. If workers() was called (without disableDefaultWorkers()), removes default workers whose class
+ *    overlaps with user-registered workers to prevent duplicates while preserving user-specified order.
  */
 final readonly class RemoveDefaultWorkersCompilerPass implements CompilerPassInterface
 {

--- a/src/DependencyInjection/CompilerPass/RemoveDefaultWorkersCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/RemoveDefaultWorkersCompilerPass.php
@@ -25,16 +25,33 @@ final readonly class RemoveDefaultWorkersCompilerPass implements CompilerPassInt
 
     public function process(ContainerBuilder $containerBuilder): void
     {
-        // Check if user disabled default workers in their config
-        if (! MBConfig::isDisableDefaultWorkers()) {
+        $taggedServices = $containerBuilder->findTaggedServiceIds(self::DEFAULT_WORKER_TAG);
+
+        if (MBConfig::isDisableDefaultWorkers()) {
+            // Remove all default workers
+            foreach (array_keys($taggedServices) as $serviceId) {
+                if ($containerBuilder->hasDefinition($serviceId)) {
+                    $containerBuilder->removeDefinition($serviceId);
+                }
+            }
+
             return;
         }
 
-        // Find and remove only services tagged as default workers
-        $taggedServices = $containerBuilder->findTaggedServiceIds(self::DEFAULT_WORKER_TAG);
+        // Remove default workers whose class was also registered by the user
+        // via workers(), to avoid duplicates
+        $userWorkerClasses = MBConfig::getUserWorkerClasses();
+        if ($userWorkerClasses === []) {
+            return;
+        }
 
         foreach (array_keys($taggedServices) as $serviceId) {
-            if ($containerBuilder->hasDefinition($serviceId)) {
+            if (! $containerBuilder->hasDefinition($serviceId)) {
+                continue;
+            }
+
+            $class = $containerBuilder->getDefinition($serviceId)->getClass() ?? $serviceId;
+            if (in_array($class, $userWorkerClasses, true)) {
                 $containerBuilder->removeDefinition($serviceId);
             }
         }


### PR DESCRIPTION
## Summary

Fixes #111

`MBConfig::workers()` does not respect the user-specified worker order. When users call `disableDefaultWorkers()` and then register workers in a specific order via `workers()`, the default workers (TagVersion, PushTag) always run first.

### Root cause

`config/config.php` registers default workers (TagVersionReleaseWorker, PushTagReleaseWorker) first. When `MBConfig::workers()` later calls `$services->set(SameClass)`, it replaces the definition but **PHP arrays preserve the original key position** — so the workers stay at the front of the container's definitions array regardless of the user's intended order.

Additionally, replacing the definition causes the `monorepo.default_worker` tag to be lost, making `RemoveDefaultWorkersCompilerPass` unable to find and remove them.

### Fix

- `MBConfig::workers()` now registers services with unique IDs (`user_release_worker.{index}`) instead of using the FQCN, so they are appended to the end of the definitions array in the user's specified order.
- `RemoveDefaultWorkersCompilerPass` now also removes default workers whose class overlaps with user-registered workers (even without `disableDefaultWorkers()`), preventing duplicates.

### Test coverage

| Scenario | Expected |
|---|---|
| Default behavior, no `workers()` call | TagVersion + PushTag registered |
| `disableDefaultWorkers()` only | No workers |
| `disableDefaultWorkers()` + `workers([TagVersion])` | Only TagVersion |
| `workers([Custom, TagVersion, PushTag])` without `disableDefaultWorkers()` | User order, no duplicates |
| `disableDefaultWorkers()` + `workers([Custom, TagVersion, PushTag])` | Exact user-specified order |