### PR TITLE
Add disablePackageReplace() and disableAutoloadMerge() opt-outs for non-library monorepos

### DIFF
--- a/packages-tests/Merge/ComposerJsonDecorator/ReplaceSectionJsonDecorator/ReplaceSectionJsonDecoratorTest.php
+++ b/packages-tests/Merge/ComposerJsonDecorator/ReplaceSectionJsonDecorator/ReplaceSectionJsonDecoratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Merge\ComposerJsonDecorator\ReplaceSectionJsonDecorator;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Merge\ComposerJsonDecorator\ReplaceSectionJsonDecorator;
+use Symplify\MonorepoBuilder\Merge\Configuration\MergedPackagesCollector;
+
+final class ReplaceSectionJsonDecoratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetDisablePackageReplaceFlag();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDisablePackageReplaceFlag();
+    }
+
+    public function testDefaultBehaviorPopulatesReplaceSection(): void
+    {
+        $mergedPackagesCollector = new MergedPackagesCollector();
+        $mergedPackagesCollector->addPackage('acme/internal-a');
+        $mergedPackagesCollector->addPackage('acme/internal-b');
+
+        $replaceSectionJsonDecorator = new ReplaceSectionJsonDecorator($mergedPackagesCollector);
+
+        $composerJson = new ComposerJson();
+        $replaceSectionJsonDecorator->decorate($composerJson);
+
+        $this->assertSame([
+            'acme/internal-a' => 'self.version',
+            'acme/internal-b' => 'self.version',
+        ], $composerJson->getReplace());
+    }
+
+    public function testDisablePackageReplaceSkipsReplaceSection(): void
+    {
+        $mergedPackagesCollector = new MergedPackagesCollector();
+        $mergedPackagesCollector->addPackage('acme/internal-a');
+        $mergedPackagesCollector->addPackage('acme/internal-b');
+
+        MBConfig::disablePackageReplace();
+
+        $replaceSectionJsonDecorator = new ReplaceSectionJsonDecorator($mergedPackagesCollector);
+
+        $composerJson = new ComposerJson();
+        $replaceSectionJsonDecorator->decorate($composerJson);
+
+        $this->assertSame([], $composerJson->getReplace());
+    }
+
+    private function resetDisablePackageReplaceFlag(): void
+    {
+        $reflectionClass = new ReflectionClass(MBConfig::class);
+
+        $reflectionProperty = $reflectionClass->getProperty('disablePackageReplace');
+        $reflectionProperty->setValue(null, false);
+    }
+}

--- a/packages-tests/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger/AutoloadComposerKeyMergerTest.php
+++ b/packages-tests/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger/AutoloadComposerKeyMergerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Merge\ComposerKeyMerger\AutoloadComposerKeyMerger;
+
+use ReflectionClass;
+use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Kernel\MonorepoBuilderKernel;
+use Symplify\MonorepoBuilder\Merge\ComposerKeyMerger\AutoloadComposerKeyMerger;
+use Symplify\MonorepoBuilder\Merge\ComposerKeyMerger\AutoloadDevComposerKeyMerger;
+use Symplify\PackageBuilder\Testing\AbstractKernelTestCase;
+
+final class AutoloadComposerKeyMergerTest extends AbstractKernelTestCase
+{
+    private AutoloadComposerKeyMerger $autoloadComposerKeyMerger;
+
+    private AutoloadDevComposerKeyMerger $autoloadDevComposerKeyMerger;
+
+    protected function setUp(): void
+    {
+        $this->bootKernel(MonorepoBuilderKernel::class);
+
+        $this->autoloadComposerKeyMerger = $this->getService(AutoloadComposerKeyMerger::class);
+        $this->autoloadDevComposerKeyMerger = $this->getService(AutoloadDevComposerKeyMerger::class);
+
+        $this->resetDisableAutoloadMergeFlag();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDisableAutoloadMergeFlag();
+    }
+
+    public function testDefaultBehaviorMergesAutoload(): void
+    {
+        $newComposerJson = new ComposerJson();
+        $newComposerJson->setAutoload([
+            'psr-4' => ['Acme\\Internal\\' => 'src'],
+        ]);
+
+        $mainComposerJson = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainComposerJson, $newComposerJson);
+
+        $this->assertSame([
+            'psr-4' => ['Acme\\Internal\\' => 'src'],
+        ], $mainComposerJson->getAutoload());
+    }
+
+    public function testDisableAutoloadMergeSkipsAutoload(): void
+    {
+        $newComposerJson = new ComposerJson();
+        $newComposerJson->setAutoload([
+            'psr-4' => ['Acme\\Internal\\' => 'src'],
+        ]);
+
+        MBConfig::disableAutoloadMerge();
+
+        $mainComposerJson = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainComposerJson, $newComposerJson);
+
+        $this->assertSame([], $mainComposerJson->getAutoload());
+    }
+
+    public function testDisableAutoloadMergeSkipsAutoloadDev(): void
+    {
+        $newComposerJson = new ComposerJson();
+        $newComposerJson->setAutoloadDev([
+            'psr-4' => ['Acme\\Internal\\Tests\\' => 'tests'],
+        ]);
+
+        MBConfig::disableAutoloadMerge();
+
+        $mainComposerJson = new ComposerJson();
+        $this->autoloadDevComposerKeyMerger->merge($mainComposerJson, $newComposerJson);
+
+        $this->assertSame([], $mainComposerJson->getAutoloadDev());
+    }
+
+    private function resetDisableAutoloadMergeFlag(): void
+    {
+        $reflectionClass = new ReflectionClass(MBConfig::class);
+
+        $reflectionProperty = $reflectionClass->getProperty('disableAutoloadMerge');
+        $reflectionProperty->setValue(null, false);
+    }
+}

--- a/packages/Merge/ComposerJsonDecorator/ReplaceSectionJsonDecorator.php
+++ b/packages/Merge/ComposerJsonDecorator/ReplaceSectionJsonDecorator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Merge\ComposerJsonDecorator;
 
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Config\MBConfig;
 use Symplify\MonorepoBuilder\Merge\Configuration\MergedPackagesCollector;
 use Symplify\MonorepoBuilder\Merge\Contract\ComposerJsonDecoratorInterface;
 
@@ -17,6 +18,10 @@ final readonly class ReplaceSectionJsonDecorator implements ComposerJsonDecorato
 
     public function decorate(ComposerJson $composerJson): void
     {
+        if (MBConfig::isPackageReplaceDisabled()) {
+            return;
+        }
+
         $mergedPackages = $this->mergedPackagesCollector->getPackages();
 
         foreach ($mergedPackages as $mergedPackage) {

--- a/packages/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger.php
+++ b/packages/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger.php
@@ -6,6 +6,7 @@ namespace Symplify\MonorepoBuilder\Merge\ComposerKeyMerger;
 
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
+use Symplify\MonorepoBuilder\Config\MBConfig;
 use Symplify\MonorepoBuilder\Merge\Arrays\SortedParameterMerger;
 use Symplify\MonorepoBuilder\Merge\Contract\ComposerKeyMergerInterface;
 
@@ -18,6 +19,10 @@ final readonly class AutoloadComposerKeyMerger implements ComposerKeyMergerInter
 
     public function merge(ComposerJson $mainComposerJson, ComposerJson $newComposerJson): void
     {
+        if (MBConfig::isAutoloadMergeDisabled()) {
+            return;
+        }
+
         if ($newComposerJson->getAutoload() === []) {
             return;
         }

--- a/packages/Merge/ComposerKeyMerger/AutoloadDevComposerKeyMerger.php
+++ b/packages/Merge/ComposerKeyMerger/AutoloadDevComposerKeyMerger.php
@@ -6,6 +6,7 @@ namespace Symplify\MonorepoBuilder\Merge\ComposerKeyMerger;
 
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
+use Symplify\MonorepoBuilder\Config\MBConfig;
 use Symplify\MonorepoBuilder\Merge\Arrays\SortedParameterMerger;
 use Symplify\MonorepoBuilder\Merge\Contract\ComposerKeyMergerInterface;
 
@@ -18,6 +19,10 @@ final readonly class AutoloadDevComposerKeyMerger implements ComposerKeyMergerIn
 
     public function merge(ComposerJson $mainComposerJson, ComposerJson $newComposerJson): void
     {
+        if (MBConfig::isAutoloadMergeDisabled()) {
+            return;
+        }
+
         if ($newComposerJson->getAutoloadDev() === []) {
             return;
         }

--- a/src-deps/package-builder/src/Testing/AbstractKernelTestCase.php
+++ b/src-deps/package-builder/src/Testing/AbstractKernelTestCase.php
@@ -75,7 +75,6 @@ abstract class AbstractKernelTestCase extends TestCase
     protected function bootKernel(string $kernelClass): void
     {
         if (is_a($kernelClass, LightKernelInterface::class, true)) {
-            /** @var LightKernelInterface $kernel */
             $kernel = new $kernelClass();
             $kernel->createFromConfigs([]);
 
@@ -200,7 +199,6 @@ abstract class AbstractKernelTestCase extends TestCase
         array $configFilePaths
     ): KernelInterface|LightKernelInterface {
         if (is_a($kernelClass, LightKernelInterface::class, true)) {
-            /** @var LightKernelInterface $kernel */
             $kernel = new $kernelClass();
             $kernel->createFromConfigs($configFilePaths);
             return $kernel;

--- a/src/Config/MBConfig.php
+++ b/src/Config/MBConfig.php
@@ -15,6 +15,8 @@ final class MBConfig extends ContainerConfigurator
 
     private static bool $disablePackageReplace = false;
 
+    private static bool $disableAutoloadMerge = false;
+
     /**
      * @var array<class-string<ReleaseWorkerInterface>>
      */
@@ -41,6 +43,11 @@ final class MBConfig extends ContainerConfigurator
         return self::$disablePackageReplace;
     }
 
+    public static function isAutoloadMergeDisabled(): bool
+    {
+        return self::$disableAutoloadMerge;
+    }
+
     /**
      * @return array<class-string<ReleaseWorkerInterface>>
      */
@@ -57,6 +64,11 @@ final class MBConfig extends ContainerConfigurator
     public static function disablePackageReplace(): void
     {
         self::$disablePackageReplace = true;
+    }
+
+    public static function disableAutoloadMerge(): void
+    {
+        self::$disableAutoloadMerge = true;
     }
 
     /**

--- a/src/Config/MBConfig.php
+++ b/src/Config/MBConfig.php
@@ -13,6 +13,8 @@ final class MBConfig extends ContainerConfigurator
 {
     private static bool $disableDefaultWorkers = false;
 
+    private static bool $disablePackageReplace = false;
+
     /**
      * @var array<class-string<ReleaseWorkerInterface>>
      */
@@ -34,6 +36,11 @@ final class MBConfig extends ContainerConfigurator
         return self::$disableDefaultWorkers;
     }
 
+    public static function isPackageReplaceDisabled(): bool
+    {
+        return self::$disablePackageReplace;
+    }
+
     /**
      * @return array<class-string<ReleaseWorkerInterface>>
      */
@@ -45,6 +52,11 @@ final class MBConfig extends ContainerConfigurator
     public static function disableDefaultWorkers(): void
     {
         self::$disableDefaultWorkers = true;
+    }
+
+    public static function disablePackageReplace(): void
+    {
+        self::$disablePackageReplace = true;
     }
 
     /**


### PR DESCRIPTION
## Summary

Two opt-in switches on `MBConfig` for monorepos that are **not** published as a library (e.g. Laravel apps using `path` repos + `self.version` requires):

- `MBConfig::disablePackageReplace()` — skip `ReplaceSectionJsonDecorator`. The default `replace: { internal/pkg: self.version }` makes Composer treat the root as already providing internal packages → they're never installed → never appear in `vendor/composer/installed.json` → Laravel's package auto-discovery breaks. Opting out fixes this.
- `MBConfig::disableAutoloadMerge()` — skip merging `autoload` / `autoload-dev` from package composer.json into root. With `replace` disabled, internal packages get installed via path repos and bring their own autoload, so the merged root entries become redundant (duplicate PSR-4 mappings).

Both follow the existing static-flag pattern of `MBConfig::disableDefaultWorkers()`. Default behavior unchanged.

## Usage

```php
return static function (MBConfig $mbConfig): void {
    MBConfig::disablePackageReplace();
    MBConfig::disableAutoloadMerge();
};
```

## Test plan

- [x] New unit tests cover default + disabled paths for replace section, autoload merge, and autoload-dev merge
- [x] Full suite green (67/275)
- [x] composer check-cs, composer check-rector, phpstan clean