### PR TITLE
Fix repositories array becoming a JSON object after path-type dedup

### DIFF
--- a/packages-tests/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
+++ b/packages-tests/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
@@ -82,7 +82,7 @@ final class RepositoryPathComposerJsonDecorator extends AbstractComposerJsonDeco
                     'type' => 'path',
                     'url' => 'libs/*/',
                 ],
-                3 => [
+                2 => [
                     'packagist.org' => false,
                 ],
             ],

--- a/packages/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
+++ b/packages/Merge/ComposerJsonDecorator/RepositoryPathComposerJsonDecorator.php
@@ -47,11 +47,12 @@ final class RepositoryPathComposerJsonDecorator implements ComposerJsonDecorator
 
             if (in_array((string) $repository['url'], $paths, true)) {
                 unset($repositories[$index]);
+                continue;
             }
 
             $paths[] = $repository['url'];
         }
 
-        $composerJson->setRepositories($repositories);
+        $composerJson->setRepositories(array_values($repositories));
     }
 }


### PR DESCRIPTION
Fixes #113.

`RepositoryPathComposerJsonDecorator::processRemoveDuplicates()` used `unset()` without reindexing, leaving non-sequential integer keys in the `repositories` array. `Nette\Utils\Json::encode()` then serializes that as a JSON object instead of an array — valid Composer-wise, but a noisy diff and breaks tooling that assumes a list.

Fix:
- Wrap the final assignment in `array_values(...)` to reindex.
- Add `continue;` after `unset()` so a discarded URL isn't re-pushed onto `$paths`.
- Update the existing decorator test fixture to assert sequential keys (was asserting the buggy `0, 1, 3`).