### PR TITLE
Honor disablePackageReplace() in RootRemoveComposerJsonDecorator

### DIFF
--- a/packages-tests/Merge/ComposerJsonDecorator/RootRemoveComposerJsonDecorator/RootRemoveComposerJsonDecoratorTest.php
+++ b/packages-tests/Merge/ComposerJsonDecorator/RootRemoveComposerJsonDecorator/RootRemoveComposerJsonDecoratorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Tests\Merge\ComposerJsonDecorator\RootRemoveComposerJsonDecorator;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Merge\ComposerJsonDecorator\RootRemoveComposerJsonDecorator;
+use Symplify\MonorepoBuilder\Merge\Configuration\MergedPackagesCollector;
+
+final class RootRemoveComposerJsonDecoratorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetDisablePackageReplaceFlag();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetDisablePackageReplaceFlag();
+    }
+
+    public function testDefaultBehaviorRemovesMergedPackagesFromRoot(): void
+    {
+        $mergedPackagesCollector = new MergedPackagesCollector();
+        $mergedPackagesCollector->addPackage('acme/internal-a');
+
+        $composerJson = new ComposerJson();
+        $composerJson->setRequire([
+            'acme/internal-a' => '^1.0',
+            'vendor/external' => '^2.0',
+        ]);
+        $composerJson->setRequireDev([
+            'acme/internal-a' => '^1.0',
+            'phpunit/phpunit' => '^10.0',
+        ]);
+
+        (new RootRemoveComposerJsonDecorator($mergedPackagesCollector))->decorate($composerJson);
+
+        $this->assertSame(['vendor/external' => '^2.0'], $composerJson->getRequire());
+        $this->assertSame(['phpunit/phpunit' => '^10.0'], $composerJson->getRequireDev());
+    }
+
+    public function testDisablePackageReplaceKeepsMergedPackagesInRoot(): void
+    {
+        $mergedPackagesCollector = new MergedPackagesCollector();
+        $mergedPackagesCollector->addPackage('acme/internal-a');
+
+        MBConfig::disablePackageReplace();
+
+        $composerJson = new ComposerJson();
+        $composerJson->setRequire([
+            'acme/internal-a' => '^1.0',
+            'vendor/external' => '^2.0',
+        ]);
+        $composerJson->setRequireDev([
+            'acme/internal-a' => '^1.0',
+            'phpunit/phpunit' => '^10.0',
+        ]);
+
+        (new RootRemoveComposerJsonDecorator($mergedPackagesCollector))->decorate($composerJson);
+
+        $this->assertSame([
+            'acme/internal-a' => '^1.0',
+            'vendor/external' => '^2.0',
+        ], $composerJson->getRequire());
+        $this->assertSame([
+            'acme/internal-a' => '^1.0',
+            'phpunit/phpunit' => '^10.0',
+        ], $composerJson->getRequireDev());
+    }
+
+    private function resetDisablePackageReplaceFlag(): void
+    {
+        $reflectionClass = new ReflectionClass(MBConfig::class);
+
+        $reflectionProperty = $reflectionClass->getProperty('disablePackageReplace');
+        $reflectionProperty->setValue(null, false);
+    }
+}

--- a/packages/Merge/ComposerJsonDecorator/RootRemoveComposerJsonDecorator.php
+++ b/packages/Merge/ComposerJsonDecorator/RootRemoveComposerJsonDecorator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Symplify\MonorepoBuilder\Merge\ComposerJsonDecorator;
 
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Config\MBConfig;
 use Symplify\MonorepoBuilder\Merge\Configuration\MergedPackagesCollector;
 use Symplify\MonorepoBuilder\Merge\Contract\ComposerJsonDecoratorInterface;
 
@@ -21,6 +22,10 @@ final readonly class RootRemoveComposerJsonDecorator implements ComposerJsonDeco
 
     public function decorate(ComposerJson $composerJson): void
     {
+        if (MBConfig::isPackageReplaceDisabled()) {
+            return;
+        }
+
         $require = $this->filterOutMergedPackages($composerJson->getRequire());
         $composerJson->setRequire($require);
 


### PR DESCRIPTION
## Summary
- `disablePackageReplace()` was incomplete: `ReplaceSectionJsonDecorator` skipped writing the `replace` block, but `RootRemoveComposerJsonDecorator` still stripped merged packages from root `require` / `require-dev`.
- Net effect: merged packages ended up neither in `replace` nor in `require`, so Composer never installed them, `vendor/<vendor>/` was missing, and autoload failed (e.g. trait-not-found at runtime).
- These two decorators are a pair (replace declares `self.version`, remove drops the now-redundant entry). Disabling one without the other is incoherent — fix is the same one-line guard.

## Test plan
- [x] New `RootRemoveComposerJsonDecoratorTest` covers default-removal and disabled-keeps-root cases.
- [x] `vendor/bin/phpunit` (69 tests, all green).
- [x] `composer check-cs`, `composer phpstan`, `composer fix-rector` all clean.