### PR TITLE
Add parameterized disableAutoloadMerge(sections, forTypes); deprecate zero-arg form

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,30 @@ Requires PHP 8.2+. For PHP 8.1, use `symplify/monorepo-builder:^11.2` (no longer
 
 ## Quick Start
 
-If you're new to monorepos, generate a basic structure:
+```bash
+# 1. Scaffold a basic monorepo layout (one time)
+vendor/bin/monorepo-builder init
+
+# 2. Fold every package's composer.json into the root composer.json
+vendor/bin/monorepo-builder merge
+
+# 3. Cut a release when you're ready
+vendor/bin/monorepo-builder release v1.0
+```
+
+All configuration goes in `monorepo-builder.php` at your project root. See [Configuration](#configuration) for the full list of options.
+
+## Commands
+
+### init
+
+Generates a basic monorepo skeleton (a `packages/` directory and a starter `monorepo-builder.php`) so you can start adding packages immediately:
 
 ```bash
 vendor/bin/monorepo-builder init
 ```
 
-All configuration goes in `monorepo-builder.php` at your project root.
-
-## Configuration
-
-### Package Directories
-
-By default, packages are discovered from `./packages`. To customize:
-
-```php
-use Symplify\MonorepoBuilder\Config\MBConfig;
-
-return static function (MBConfig $mbConfig): void {
-    $mbConfig->packageDirectories([
-        __DIR__ . '/packages',
-        __DIR__ . '/projects',
-    ]);
-
-    // exclude specific packages
-    $mbConfig->packageDirectoriesExcludes([__DIR__ . '/packages/secret-package']);
-};
-```
-
-## Commands
+Run once at the start of a new monorepo. Existing files are not overwritten.
 
 ### merge
 
@@ -58,7 +53,106 @@ vendor/bin/monorepo-builder merge
 - If a package appears in both `require` and `require-dev`, the `require` entry takes priority
 - The original key order of the root `composer.json` is preserved; new sections are appended at the end
 
-**Append and remove data after merge:**
+To customize what gets merged (append / remove data, reorder sections, skip autoload merging, etc.) see [Customizing merge output](#customizing-merge-output).
+
+### validate
+
+Checks that all packages use the same version for shared dependencies:
+
+```bash
+vendor/bin/monorepo-builder validate
+```
+
+### bump-interdependency
+
+Updates mutual dependencies between packages to a given version:
+
+```bash
+vendor/bin/monorepo-builder bump-interdependency "^4.0"
+```
+
+### propagate
+
+Propagates versions from root `composer.json` back to each package's `composer.json` (the reverse of [`merge`](#merge)):
+
+```bash
+vendor/bin/monorepo-builder propagate
+```
+
+### package-alias
+
+Updates the `branch-alias` in every package `composer.json` to match the current version:
+
+```bash
+vendor/bin/monorepo-builder package-alias
+```
+
+To customize the alias format string, see [Custom alias format](#custom-alias-format) under Configuration.
+
+### localize-composer-paths
+
+Sets mutual package paths to local packages for pre-split testing:
+
+```bash
+vendor/bin/monorepo-builder localize-composer-paths
+```
+
+### release
+
+Automates the release process: bumping dependencies, tagging, pushing, and updating changelogs.
+
+```bash
+vendor/bin/monorepo-builder release v7.0
+```
+
+Preview what will happen without making changes:
+
+```bash
+vendor/bin/monorepo-builder release v7.0 --dry-run
+```
+
+Release by semver level (`patch`, `minor`, or `major`):
+
+```bash
+# current v0.7.1 → v0.7.2
+vendor/bin/monorepo-builder release patch
+```
+
+The default pipeline runs `TagVersionReleaseWorker` followed by `PushTagReleaseWorker`. To customize the pipeline (add workers, reorder, disable defaults, enable LTS-aware tag resolution), see [Customizing the release pipeline](#customizing-the-release-pipeline).
+
+## Configuration
+
+All configuration lives in `monorepo-builder.php` at your project root. Every option below is set on the `MBConfig` instance passed into the configurator closure:
+
+```php
+use Symplify\MonorepoBuilder\Config\MBConfig;
+
+return static function (MBConfig $mbConfig): void {
+    // your configuration here
+};
+```
+
+### Package discovery
+
+By default, packages are discovered from `./packages`. To customize:
+
+```php
+return static function (MBConfig $mbConfig): void {
+    $mbConfig->packageDirectories([
+        __DIR__ . '/packages',
+        __DIR__ . '/projects',
+    ]);
+
+    // exclude specific packages
+    $mbConfig->packageDirectoriesExcludes([__DIR__ . '/packages/secret-package']);
+};
+```
+
+### Customizing merge output
+
+These options shape what `vendor/bin/monorepo-builder merge` writes into the root `composer.json`.
+
+#### Append / remove data after merge
 
 ```php
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
@@ -91,9 +185,9 @@ return static function (MBConfig $mbConfig): void {
 };
 ```
 
-**Custom section order:**
+#### Section ordering
 
-By default, the original key order is preserved. To enforce a specific order:
+By default, the original key order of root `composer.json` is preserved. To enforce a specific order:
 
 ```php
 use Symplify\MonorepoBuilder\Config\MBConfig;
@@ -104,79 +198,86 @@ return static function (MBConfig $mbConfig): void {
 };
 ```
 
-### validate
+#### Skip autoload merging for selected packages
 
-Checks that all packages use the same version for shared dependencies:
+By default, every internal package's `autoload` and `autoload-dev` PSR-4 entries are folded into the root `composer.json` so that `vendor/bin/phpunit` and other root-level tooling can resolve every namespace. The three scenarios below cover when you'd want to skip part or all of that merging — pick the one that matches your monorepo:
 
-```bash
-vendor/bin/monorepo-builder validate
+**Scenario 1 — Default monorepo of libraries.** No skip needed. The root `composer.json` `autoload` aggregates every internal library's PSR-4 mapping, so any namespace resolves from the root vendor.
+
+**Scenario 2 — Mixed monorepo with libraries symlinked + apps not required from root.** When [`disablePackageReplace()`](#skip-the-package-replace-section) is on (libraries are real path-repo deps, Composer symlinks them into `vendor/`), the libraries' `autoload` is registered automatically by Composer via `vendor/composer/autoload_psr4.php`. Folding them into the root `composer.json` would duplicate that registration. Skip autoload merging for libraries only — apps' autoload still merges so root-level scripts can find them:
+
+```php
+use Symplify\MonorepoBuilder\Config\AutoloadSection;
+use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Config\PackageType;
+
+return static function (MBConfig $mbConfig): void {
+    $mbConfig->disablePackageReplace();
+    $mbConfig->disableAutoloadMerge(
+        sections: [AutoloadSection::Autoload],
+        forTypes: [PackageType::Library],
+    );
+};
 ```
 
-### bump-interdependency
+Result: root `autoload` contains apps' PSR-4 entries but NOT libraries'. Root `autoload-dev` still aggregates everything (see "Why autoload-dev is independent" below).
 
-Updates mutual dependencies between packages to a given version:
+**Scenario 3 — Custom merge.** To turn off both sections entirely (you handle merging yourself, e.g. via a custom decorator):
 
-```bash
-vendor/bin/monorepo-builder bump-interdependency "^4.0"
+```php
+use Symplify\MonorepoBuilder\Config\AutoloadSection;
+use Symplify\MonorepoBuilder\Config\MBConfig;
+
+return static function (MBConfig $mbConfig): void {
+    $mbConfig->disableAutoloadMerge(
+        sections: [AutoloadSection::Autoload, AutoloadSection::AutoloadDev],
+        forTypes: [],
+    );
+};
 ```
 
-### propagate
+Result: root `autoload` and `autoload-dev` are untouched by `monorepo-builder merge`.
 
-Propagates versions from root `composer.json` to all packages (the reverse of `merge`):
+**API reference:**
+- `disableAutoloadMerge(array $sections, array $forTypes)` — both arguments are required.
+  - `$sections`: a non-empty list of `AutoloadSection` cases (`Autoload`, `AutoloadDev`).
+  - `$forTypes`: a list of composer.json `type` filter values. **Each element may be either a `PackageType` enum case (preferred for the four [Composer schema](https://getcomposer.org/doc/04-schema.md#type) types: `Library`, `Project`, `Metapackage`, `ComposerPlugin`) or a non-empty string (escape hatch for ecosystem types defined by `composer/installers` such as `'wordpress-plugin'`, `'drupal-module'`, `'symfony-bundle'`, and for user-defined custom types).** Mixing enum cases and strings in the same call is allowed; multiple types are OR-matched. The two filter channels are intentionally distinct: pass an **empty array** (`forTypes: []`) to skip every package regardless of type, OR pass a non-empty list of types to skip ONLY packages whose `composer.json` declares the matching `type` literally. Composer's "missing `type` defaults to library" rule does NOT extend the filter — a package without an explicit `type` field is NOT swept up by `forTypes: [PackageType::Library]`. If you want the filter to catch an untyped package, declare `type: library` (or whichever) in that package's `composer.json`.
+- Repeated calls follow last-call-wins semantics PER section. Calls touching different sections compose; calls touching the same section override.
 
-```bash
-vendor/bin/monorepo-builder propagate
-```
+**Migrating from the previous binary API:** The earlier zero-argument form `$mbConfig->disableAutoloadMerge();` continues to work but is deprecated and emits an `E_USER_DEPRECATED` notice. It maps to the full-kill behavior — equivalent to `disableAutoloadMerge(sections: [AutoloadSection::Autoload, AutoloadSection::AutoloadDev], forTypes: [])`. Update existing config files at your convenience. The legacy `MBConfig::isAutoloadMergeDisabled()` getter is also kept as a deprecated convenience that returns `true` only when both sections are configured to skip merging for all packages — prefer `MBConfig::shouldSkipAutoload($packageType)` and `MBConfig::shouldSkipAutoloadDev($packageType)` for new code.
 
-### package-alias
+##### Why autoload-dev is independent
 
-Updates the `branch-alias` in every package `composer.json` to match the current version:
+Composer treats `autoload-dev` as a **root-only** section: dev autoload entries from path-repo dependencies are NEVER registered in the consumer's `vendor/composer/autoload_psr4.php`. (See [Composer schema docs — `autoload-dev`](https://getcomposer.org/doc/04-schema.md#autoload-dev).)
 
-```bash
-vendor/bin/monorepo-builder package-alias
-```
+Practical consequence: if your CI runs `vendor/bin/phpunit` from the monorepo root and expects to discover library test classes, those test classes are reachable ONLY because `monorepo-builder merge` has folded each library's `autoload-dev` PSR-4 into the root `composer.json`. Skipping `AutoloadSection::AutoloadDev` from root merge therefore breaks cross-package PHPUnit discovery — skip it only when you're handling test discovery another way.
 
-To customize the alias format:
+#### Skip the package-replace section
+
+By default, `monorepo-builder merge` writes a `replace` section into the root `composer.json` listing every internal package at `self.version`. This is correct for monorepos that publish a single combined dependency surface — Composer then refuses to install any external copy of those packages.
+
+Some monorepos do NOT want this:
+
+- Apps that require their own internal libraries via `path` repositories and rely on Composer's symlink installation (the `replace` entry would short-circuit the symlink)
+- Monorepos with mixed `type: library` packages and `type: project` apps where the apps need real installs of the libs
+
+To skip writing the `replace` section entirely:
 
 ```php
 use Symplify\MonorepoBuilder\Config\MBConfig;
 
 return static function (MBConfig $mbConfig): void {
-    // default: "<major>.<minor>-dev"
-    $mbConfig->packageAliasFormat('<major>.<minor>.x-dev');
+    $mbConfig->disablePackageReplace();
 };
 ```
 
-### localize-composer-paths
+This pairs naturally with [Scenario 2 of the autoload skip section](#skip-autoload-merging-for-selected-packages) above. With both opt-outs on, your `path`-repository-based libraries get symlink-installed by Composer and only your apps' autoload entries land in the root `composer.json`.
 
-Sets mutual package paths to local packages for pre-split testing:
+### Customizing the release pipeline
 
-```bash
-vendor/bin/monorepo-builder localize-composer-paths
-```
+These options shape what `vendor/bin/monorepo-builder release` does on each invocation.
 
-### release
-
-Automates the release process: bumping dependencies, tagging, pushing, and updating changelogs.
-
-```bash
-vendor/bin/monorepo-builder release v7.0
-```
-
-Preview what will happen without making changes:
-
-```bash
-vendor/bin/monorepo-builder release v7.0 --dry-run
-```
-
-Release by semver level (`patch`, `minor`, or `major`):
-
-```bash
-# current v0.7.1 -> v0.7.2
-vendor/bin/monorepo-builder release patch
-```
-
-**Configuring release workers:**
+#### Custom workers
 
 `TagVersionReleaseWorker` and `PushTagReleaseWorker` are enabled by default. Add more workers or customize the order:
 
@@ -205,7 +306,7 @@ return static function (MBConfig $mbConfig): void {
 };
 ```
 
-To disable the default workers:
+To disable the default workers (and define your pipeline from scratch):
 
 ```php
 return static function (MBConfig $mbConfig): void {
@@ -215,19 +316,32 @@ return static function (MBConfig $mbConfig): void {
 
 You can also add custom workers by implementing `ReleaseWorkerInterface`.
 
-**Branch-aware tag validation (LTS):**
+#### Branch-aware tag validation (LTS)
 
 If you maintain multiple version lines, the release command may reject older versions because it compares against the most recent tag globally. Enable branch-aware validation to compare only within the same major version:
 
 ```php
 use Symplify\MonorepoBuilder\Config\MBConfig;
-use Symplify\MonorepoBuilder\Git\BranchAwareTagResolver;
 use Symplify\MonorepoBuilder\Contract\Git\TagResolverInterface;
+use Symplify\MonorepoBuilder\Git\BranchAwareTagResolver;
 
 return static function (MBConfig $mbConfig): void {
     $services = $mbConfig->services();
     $services->set(BranchAwareTagResolver::class);
     $services->alias(TagResolverInterface::class, BranchAwareTagResolver::class);
+};
+```
+
+#### Custom alias format
+
+`vendor/bin/monorepo-builder package-alias` writes a `branch-alias` entry into every package `composer.json`. To override the format string used:
+
+```php
+use Symplify\MonorepoBuilder\Config\MBConfig;
+
+return static function (MBConfig $mbConfig): void {
+    // default: "<major>.<minor>-dev"
+    $mbConfig->packageAliasFormat('<major>.<minor>.x-dev');
 };
 ```
 

--- a/packages-tests/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger/AutoloadComposerKeyMergerTest.php
+++ b/packages-tests/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger/AutoloadComposerKeyMergerTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Tests\Merge\ComposerKeyMerger\AutoloadComposerKeyMerger;
 
+use InvalidArgumentException;
 use ReflectionClass;
 use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJson;
+use Symplify\MonorepoBuilder\Config\AutoloadSection;
 use Symplify\MonorepoBuilder\Config\MBConfig;
+use Symplify\MonorepoBuilder\Config\PackageType;
 use Symplify\MonorepoBuilder\Kernel\MonorepoBuilderKernel;
 use Symplify\MonorepoBuilder\Merge\ComposerKeyMerger\AutoloadComposerKeyMerger;
 use Symplify\MonorepoBuilder\Merge\ComposerKeyMerger\AutoloadDevComposerKeyMerger;
@@ -25,64 +28,412 @@ final class AutoloadComposerKeyMergerTest extends AbstractKernelTestCase
         $this->autoloadComposerKeyMerger = $this->getService(AutoloadComposerKeyMerger::class);
         $this->autoloadDevComposerKeyMerger = $this->getService(AutoloadDevComposerKeyMerger::class);
 
-        $this->resetDisableAutoloadMergeFlag();
+        $this->resetMBConfigStaticFlags();
     }
 
     protected function tearDown(): void
     {
-        $this->resetDisableAutoloadMergeFlag();
+        $this->resetMBConfigStaticFlags();
     }
 
-    public function testDefaultBehaviorMergesAutoload(): void
+    public function testNoRuleSetMergesAutoloadAndAutoloadDev(): void
     {
-        $newComposerJson = new ComposerJson();
-        $newComposerJson->setAutoload([
-            'psr-4' => ['Acme\\Internal\\' => 'src'],
-        ]);
+        $packageJson = $this->makePackage('library');
+        $composerJson = new ComposerJson();
 
-        $mainComposerJson = new ComposerJson();
-        $this->autoloadComposerKeyMerger->merge($mainComposerJson, $newComposerJson);
+        $this->autoloadComposerKeyMerger->merge($composerJson, $packageJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $packageJson);
 
         $this->assertSame([
-            'psr-4' => ['Acme\\Internal\\' => 'src'],
-        ], $mainComposerJson->getAutoload());
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $composerJson->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $composerJson->getAutoloadDev());
     }
 
-    public function testDisableAutoloadMergeSkipsAutoload(): void
+    public function testSkipBothForAllPackagesEmptiesBothSections(): void
     {
-        $newComposerJson = new ComposerJson();
-        $newComposerJson->setAutoload([
-            'psr-4' => ['Acme\\Internal\\' => 'src'],
+        MBConfig::disableAutoloadMerge(
+            [AutoloadSection::Autoload, AutoloadSection::AutoloadDev],
+            []
+        );
+
+        // Test for library type
+        $libraryJson = $this->makePackage('library');
+        $mainJson1 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson1, $libraryJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson1, $libraryJson);
+        $this->assertSame([], $mainJson1->getAutoload());
+        $this->assertSame([], $mainJson1->getAutoloadDev());
+
+        // Test for project type
+        $projectJson = $this->makePackage('project');
+        $mainJson2 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson2, $projectJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson2, $projectJson);
+        $this->assertSame([], $mainJson2->getAutoload());
+        $this->assertSame([], $mainJson2->getAutoloadDev());
+
+        // Test for null type
+        $nullTypeJson = $this->makePackage(null);
+        $mainJson3 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson3, $nullTypeJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson3, $nullTypeJson);
+        $this->assertSame([], $mainJson3->getAutoload());
+        $this->assertSame([], $mainJson3->getAutoloadDev());
+    }
+
+    public function testSkipAutoloadOnlyForAllLeavesAutoloadDevMerged(): void
+    {
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], []);
+
+        $packageJson = $this->makePackage('library');
+        $composerJson = new ComposerJson();
+
+        $this->autoloadComposerKeyMerger->merge($composerJson, $packageJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $packageJson);
+
+        $this->assertSame([], $composerJson->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $composerJson->getAutoloadDev());
+    }
+
+    public function testSkipAutoloadDevOnlyForAllLeavesAutoloadMerged(): void
+    {
+        MBConfig::disableAutoloadMerge([AutoloadSection::AutoloadDev], []);
+
+        $packageJson = $this->makePackage('library');
+        $composerJson = new ComposerJson();
+
+        $this->autoloadComposerKeyMerger->merge($composerJson, $packageJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $packageJson);
+
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $composerJson->getAutoload());
+        $this->assertSame([], $composerJson->getAutoloadDev());
+    }
+
+    public function testSkipAutoloadForLibrariesOnlySkipsLibrary(): void
+    {
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], [PackageType::Library]);
+
+        $packageJson = $this->makePackage('library');
+        $composerJson = new ComposerJson();
+
+        $this->autoloadComposerKeyMerger->merge($composerJson, $packageJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $packageJson);
+
+        $this->assertSame([], $composerJson->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $composerJson->getAutoloadDev());
+    }
+
+    public function testSkipAutoloadForLibrariesOnlyMergesProject(): void
+    {
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], [PackageType::Library]);
+
+        $packageJson = $this->makePackage('project');
+        $composerJson = new ComposerJson();
+
+        $this->autoloadComposerKeyMerger->merge($composerJson, $packageJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $packageJson);
+
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $composerJson->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $composerJson->getAutoloadDev());
+    }
+
+    public function testSkipAutoloadForLibrariesOnlyMergesMissingType(): void
+    {
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], [PackageType::Library]);
+
+        $packageJson = $this->makePackage(null);
+        $composerJson = new ComposerJson();
+
+        $this->autoloadComposerKeyMerger->merge($composerJson, $packageJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $packageJson);
+
+        // Strict literal match: a package that omits the `type` field does NOT match [PackageType::Library].
+        // Pass `forTypes: []` to skip every package regardless of type. This keeps the two channels distinct:
+        // explicit type-filters target ONLY packages that declare the matching `type` themselves.
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $composerJson->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $composerJson->getAutoloadDev());
+    }
+
+    public function testSkipAutoloadForProjectsOnlyMergesMissingType(): void
+    {
+        // Same strict literal rule for the inverse case: filtering by PackageType::Project does NOT match
+        // untyped packages either. The only way to skip ALL packages regardless of type is `forTypes: []`.
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], [PackageType::Project]);
+
+        $packageJson = $this->makePackage(null);
+        $composerJson = new ComposerJson();
+
+        $this->autoloadComposerKeyMerger->merge($composerJson, $packageJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $packageJson);
+
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $composerJson->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $composerJson->getAutoloadDev());
+    }
+
+    public function testSkipBothForLibrariesOnlySkipsLibraryButMergesProject(): void
+    {
+        MBConfig::disableAutoloadMerge(
+            [AutoloadSection::Autoload, AutoloadSection::AutoloadDev],
+            [PackageType::Library]
+        );
+
+        // Library type - both sections skipped
+        $libraryJson = $this->makePackage('library');
+        $mainJson1 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson1, $libraryJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson1, $libraryJson);
+        $this->assertSame([], $mainJson1->getAutoload());
+        $this->assertSame([], $mainJson1->getAutoloadDev());
+
+        // Project type - both sections merged
+        $projectJson = $this->makePackage('project');
+        $mainJson2 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson2, $projectJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson2, $projectJson);
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $mainJson2->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $mainJson2->getAutoloadDev());
+    }
+
+    public function testLastCallWinsForSameSection(): void
+    {
+        // First call: skip autoload only for libraries
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], [PackageType::Library]);
+
+        // Second call: skip autoload for ALL packages (overrides first call for Autoload section)
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], []);
+
+        // For a project package, the second call now wins (autoload IS skipped despite type being project)
+        $projectJson = $this->makePackage('project');
+        $composerJson = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($composerJson, $projectJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $projectJson);
+
+        $this->assertSame([], $composerJson->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $composerJson->getAutoloadDev());
+    }
+
+    public function testIndependentSectionsCompose(): void
+    {
+        // Call 1: skip autoload for libraries
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], [PackageType::Library]);
+
+        // Call 2: skip autoload-dev for libraries (different section, rules combine)
+        MBConfig::disableAutoloadMerge([AutoloadSection::AutoloadDev], [PackageType::Library]);
+
+        // For library: both sections skipped (rules compose)
+        $libraryJson = $this->makePackage('library');
+        $mainJson1 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson1, $libraryJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson1, $libraryJson);
+        $this->assertSame([], $mainJson1->getAutoload());
+        $this->assertSame([], $mainJson1->getAutoloadDev());
+
+        // For project: both sections merged (type doesn't match 'library')
+        $projectJson = $this->makePackage('project');
+        $mainJson2 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson2, $projectJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson2, $projectJson);
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $mainJson2->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $mainJson2->getAutoloadDev());
+    }
+
+    public function testForTypesAcceptsPlainStringEscapeHatch(): void
+    {
+        // Hybrid API: composer/installers types (and user-defined types) MUST work as plain strings
+        // even though they are not part of the four-case PackageType enum derived from the official schema.
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], ['wordpress-plugin']);
+
+        // Package with the wordpress-plugin type → autoload skipped via the string match
+        $wpPackageJson = $this->makePackage('wordpress-plugin');
+        $mainJson1 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson1, $wpPackageJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson1, $wpPackageJson);
+        $this->assertSame([], $mainJson1->getAutoload());
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
+        ], $mainJson1->getAutoloadDev());
+
+        // Library type → still merged (string filter doesn't include 'library')
+        $libraryJson = $this->makePackage('library');
+        $mainJson2 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson2, $libraryJson);
+        $this->autoloadDevComposerKeyMerger->merge($mainJson2, $libraryJson);
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $mainJson2->getAutoload());
+    }
+
+    public function testForTypesMixesEnumAndStringInOneCall(): void
+    {
+        // The hybrid type accepts both enum cases and plain strings in the same array.
+        MBConfig::disableAutoloadMerge(
+            [AutoloadSection::Autoload],
+            [PackageType::Library, 'symfony-bundle']
+        );
+
+        // Library matches via enum case
+        $libraryJson = $this->makePackage('library');
+        $mainJson1 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson1, $libraryJson);
+        $this->assertSame([], $mainJson1->getAutoload());
+
+        // symfony-bundle matches via plain string
+        $sfBundleJson = $this->makePackage('symfony-bundle');
+        $mainJson2 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson2, $sfBundleJson);
+        $this->assertSame([], $mainJson2->getAutoload());
+
+        // Project does NOT match — autoload still merges
+        $projectJson = $this->makePackage('project');
+        $mainJson3 = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($mainJson3, $projectJson);
+        $this->assertSame([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
+        ], $mainJson3->getAutoload());
+    }
+
+    public function testLegacyZeroArgFormStillSkipsBothSectionsForAllPackages(): void
+    {
+        // Back-compat: zero-arg disableAutoloadMerge() must continue to behave as a full kill switch.
+        // Suppress the deprecation notice for this assertion path; the trigger itself is verified separately.
+        @MBConfig::disableAutoloadMerge();
+
+        $libraryJson = $this->makePackage('library');
+        $composerJson = new ComposerJson();
+        $this->autoloadComposerKeyMerger->merge($composerJson, $libraryJson);
+        $this->autoloadDevComposerKeyMerger->merge($composerJson, $libraryJson);
+
+        $this->assertSame([], $composerJson->getAutoload());
+        $this->assertSame([], $composerJson->getAutoloadDev());
+    }
+
+    public function testLegacyZeroArgFormTriggersDeprecation(): void
+    {
+        $captured = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$captured): bool {
+            if ($errno === E_USER_DEPRECATED) {
+                $captured[] = $errstr;
+            }
+
+            return true;
+        });
+
+        try {
+            MBConfig::disableAutoloadMerge();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertCount(1, $captured);
+        $this->assertStringContainsString('deprecated', $captured[0]);
+        $this->assertStringContainsString('disableAutoloadMerge', $captured[0]);
+    }
+
+    public function testCallingWithOnlyOneArgumentThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires both $sections and $forTypes');
+
+        /** @phpstan-ignore-next-line argument.type */
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload]);
+    }
+
+    public function testIsAutoloadMergeDisabledTrueOnlyWhenBothSectionsSkipAll(): void
+    {
+        // Back-compat getter: matches the legacy semantic of "the binary disable flag was set"
+        $this->assertFalse(MBConfig::isAutoloadMergeDisabled(), 'fresh state — no rule set');
+
+        // Partial skip → not "fully disabled"
+        MBConfig::disableAutoloadMerge([AutoloadSection::Autoload], []);
+        $this->assertFalse(MBConfig::isAutoloadMergeDisabled(), 'autoload-only skip → not full kill');
+
+        $this->resetMBConfigStaticFlags();
+        MBConfig::disableAutoloadMerge([AutoloadSection::AutoloadDev], []);
+        $this->assertFalse(MBConfig::isAutoloadMergeDisabled(), 'autoload-dev-only skip → not full kill');
+
+        // Full kill via parameterized form
+        $this->resetMBConfigStaticFlags();
+        MBConfig::disableAutoloadMerge(
+            [AutoloadSection::Autoload, AutoloadSection::AutoloadDev],
+            []
+        );
+        $this->assertTrue(MBConfig::isAutoloadMergeDisabled(), 'both sections + all packages → full kill');
+
+        // Full kill via legacy zero-arg
+        $this->resetMBConfigStaticFlags();
+        @MBConfig::disableAutoloadMerge();
+        $this->assertTrue(MBConfig::isAutoloadMergeDisabled(), 'legacy zero-arg → full kill');
+
+        // Filter-by-type → not "fully disabled" (only some packages skipped)
+        $this->resetMBConfigStaticFlags();
+        MBConfig::disableAutoloadMerge(
+            [AutoloadSection::Autoload, AutoloadSection::AutoloadDev],
+            [PackageType::Library]
+        );
+        $this->assertFalse(MBConfig::isAutoloadMergeDisabled(), 'library-only filter → not full kill');
+    }
+
+    private function makePackage(?string $type): ComposerJson
+    {
+        $composerJson = new ComposerJson();
+
+        // ComposerJson doesn't expose a setType() method, use reflection to set the type field
+        if ($type !== null) {
+            $reflectionClass = new ReflectionClass($composerJson);
+            $typeProperty = $reflectionClass->getProperty('type');
+            $typeProperty->setValue($composerJson, $type);
+        }
+
+        $composerJson->setAutoload([
+            'psr-4' => ['Acme\\Lib\\' => 'src'],
         ]);
 
-        MBConfig::disableAutoloadMerge();
-
-        $mainComposerJson = new ComposerJson();
-        $this->autoloadComposerKeyMerger->merge($mainComposerJson, $newComposerJson);
-
-        $this->assertSame([], $mainComposerJson->getAutoload());
-    }
-
-    public function testDisableAutoloadMergeSkipsAutoloadDev(): void
-    {
-        $newComposerJson = new ComposerJson();
-        $newComposerJson->setAutoloadDev([
-            'psr-4' => ['Acme\\Internal\\Tests\\' => 'tests'],
+        $composerJson->setAutoloadDev([
+            'psr-4' => ['Acme\\Lib\\Tests\\' => 'tests'],
         ]);
 
-        MBConfig::disableAutoloadMerge();
-
-        $mainComposerJson = new ComposerJson();
-        $this->autoloadDevComposerKeyMerger->merge($mainComposerJson, $newComposerJson);
-
-        $this->assertSame([], $mainComposerJson->getAutoloadDev());
+        return $composerJson;
     }
 
-    private function resetDisableAutoloadMergeFlag(): void
+    private function resetMBConfigStaticFlags(): void
     {
         $reflectionClass = new ReflectionClass(MBConfig::class);
 
-        $reflectionProperty = $reflectionClass->getProperty('disableAutoloadMerge');
-        $reflectionProperty->setValue(null, false);
+        $reflectionProperty = $reflectionClass->getProperty('skippedAutoloadForTypes');
+        $reflectionProperty->setValue(null, null);
+
+        $skippedAutoloadDevForTypes = $reflectionClass->getProperty('skippedAutoloadDevForTypes');
+        $skippedAutoloadDevForTypes->setValue(null, null);
     }
 }

--- a/packages/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger.php
+++ b/packages/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger.php
@@ -19,7 +19,7 @@ final readonly class AutoloadComposerKeyMerger implements ComposerKeyMergerInter
 
     public function merge(ComposerJson $mainComposerJson, ComposerJson $newComposerJson): void
     {
-        if (MBConfig::isAutoloadMergeDisabled()) {
+        if (MBConfig::shouldSkipAutoload($newComposerJson->getType())) {
             return;
         }
 

--- a/packages/Merge/ComposerKeyMerger/AutoloadDevComposerKeyMerger.php
+++ b/packages/Merge/ComposerKeyMerger/AutoloadDevComposerKeyMerger.php
@@ -19,7 +19,7 @@ final readonly class AutoloadDevComposerKeyMerger implements ComposerKeyMergerIn
 
     public function merge(ComposerJson $mainComposerJson, ComposerJson $newComposerJson): void
     {
-        if (MBConfig::isAutoloadMergeDisabled()) {
+        if (MBConfig::shouldSkipAutoloadDev($newComposerJson->getType())) {
             return;
         }
 

--- a/src/Config/AutoloadSection.php
+++ b/src/Config/AutoloadSection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Config;
+
+enum AutoloadSection: string
+{
+    case Autoload = 'autoload';
+    case AutoloadDev = 'autoload-dev';
+}

--- a/src/Config/MBConfig.php
+++ b/src/Config/MBConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Symplify\MonorepoBuilder\Config;
 
+use InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\MonorepoBuilder\Release\Contract\ReleaseWorker\ReleaseWorkerInterface;
 use Symplify\MonorepoBuilder\ValueObject\Option;
@@ -15,7 +16,17 @@ final class MBConfig extends ContainerConfigurator
 
     private static bool $disablePackageReplace = false;
 
-    private static bool $disableAutoloadMerge = false;
+    /**
+     * null = no skip rule set; empty array = skip for all packages; non-empty = skip only for matching package types.
+     * @var array<int, string>|null
+     */
+    private static ?array $skippedAutoloadForTypes = null;
+
+    /**
+     * Same shape and semantics as $skippedAutoloadForTypes, applied to autoload-dev.
+     * @var array<int, string>|null
+     */
+    private static ?array $skippedAutoloadDevForTypes = null;
 
     /**
      * @var array<class-string<ReleaseWorkerInterface>>
@@ -43,11 +54,6 @@ final class MBConfig extends ContainerConfigurator
         return self::$disablePackageReplace;
     }
 
-    public static function isAutoloadMergeDisabled(): bool
-    {
-        return self::$disableAutoloadMerge;
-    }
-
     /**
      * @return array<class-string<ReleaseWorkerInterface>>
      */
@@ -66,9 +72,70 @@ final class MBConfig extends ContainerConfigurator
         self::$disablePackageReplace = true;
     }
 
-    public static function disableAutoloadMerge(): void
+    /**
+     * Skip merging the given composer.json sections from internal packages into the root composer.json.
+     *
+     * Repeated calls follow last-call-wins semantics PER SECTION. Calls touching different sections compose;
+     * calls touching the same section override.
+     *
+     * @param AutoloadSection[]|null $sections list of AutoloadSection cases. Pass null together with $forTypes=null
+     *        for the deprecated zero-arg legacy form (skips both sections for all packages with a deprecation notice).
+     * @param array<PackageType|string>|null $forTypes empty array means "all packages"; non-empty filters by
+     *        composer.json `type`. Each element MUST be either a {@see PackageType} enum case (preferred for the
+     *        four schema-documented types) or a non-empty string (escape hatch for composer/installers types like
+     *        `wordpress-plugin`, `drupal-module`, `symfony-bundle` and user-defined types). Pass null together with
+     *        $sections=null for the deprecated zero-arg legacy form.
+     */
+    public static function disableAutoloadMerge(?array $sections = null, ?array $forTypes = null): void
     {
-        self::$disableAutoloadMerge = true;
+        if ($sections === null && $forTypes === null) {
+            @trigger_error(
+                'Calling MBConfig::disableAutoloadMerge() with no arguments is deprecated.'
+                . ' Use the parameterized form: disableAutoloadMerge(sections: [AutoloadSection::Autoload,'
+                . ' AutoloadSection::AutoloadDev], forTypes: []) for the equivalent full-kill behavior.',
+                E_USER_DEPRECATED,
+            );
+            $sections = [AutoloadSection::Autoload, AutoloadSection::AutoloadDev];
+            $forTypes = [];
+        } elseif ($sections === null || $forTypes === null) {
+            throw new InvalidArgumentException(
+                'MBConfig::disableAutoloadMerge() requires both $sections and $forTypes when either is provided.'
+                . ' Use the zero-argument form only for the deprecated legacy full-kill behavior.',
+            );
+        }
+
+        Assert::notEmpty($sections, '$sections must contain at least one AutoloadSection case.');
+
+        $normalizedForTypes = self::normalizeForTypes($forTypes);
+
+        foreach ($sections as $section) {
+            // Exhaustive enum match — throws \UnhandledMatchError at runtime if a non-AutoloadSection element sneaks in
+            match ($section) {
+                AutoloadSection::Autoload => self::$skippedAutoloadForTypes = $normalizedForTypes,
+                AutoloadSection::AutoloadDev => self::$skippedAutoloadDevForTypes = $normalizedForTypes,
+            };
+        }
+    }
+
+    public static function shouldSkipAutoload(?string $packageType): bool
+    {
+        return self::shouldSkip(self::$skippedAutoloadForTypes, $packageType);
+    }
+
+    public static function shouldSkipAutoloadDev(?string $packageType): bool
+    {
+        return self::shouldSkip(self::$skippedAutoloadDevForTypes, $packageType);
+    }
+
+    /**
+     * @deprecated since the parameterized disableAutoloadMerge() API was introduced. Use {@see shouldSkipAutoload()}
+     *             and {@see shouldSkipAutoloadDev()} for per-package decisions. This getter returns true ONLY when
+     *             both autoload sections are configured to skip merging for ALL packages (matching the legacy
+     *             zero-argument disableAutoloadMerge() behavior).
+     */
+    public static function isAutoloadMergeDisabled(): bool
+    {
+        return self::$skippedAutoloadForTypes === [] && self::$skippedAutoloadDevForTypes === [];
     }
 
     /**
@@ -134,5 +201,57 @@ final class MBConfig extends ContainerConfigurator
     {
         $parameters = $this->parameters();
         $parameters->set(Option::SECTION_ORDER, $sectionOrder);
+    }
+
+    /**
+     * Normalize a hybrid forTypes list (PackageType cases + non-empty strings) to a string[] for internal storage.
+     *
+     * @param array<PackageType|string> $forTypes
+     * @return string[]
+     */
+    private static function normalizeForTypes(array $forTypes): array
+    {
+        $normalized = [];
+        foreach ($forTypes as $forType) {
+            if ($forType instanceof PackageType) {
+                $normalized[] = $forType->value;
+                continue;
+            }
+
+            Assert::stringNotEmpty(
+                $forType,
+                '$forTypes elements must be either a PackageType enum case or a non-empty string.',
+            );
+            $normalized[] = $forType;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Resolve whether a section should be skipped for a package, given the configured filter rule.
+     *
+     * Three branches keep the two filter channels distinct so callers can reason about them precisely:
+     *   - null filter list = no rule was set, the section merges normally.
+     *   - empty filter list = no type discrimination, every package is skipped.
+     *   - non-empty filter list = strict literal match on the package type, only packages that explicitly
+     *     declare a matching type in their own composer.json are skipped. Packages without an explicit
+     *     type field are intentionally NOT swept up — even though Composer itself defaults a missing type
+     *     to library for installation purposes, this filter requires authors to declare the type to be
+     *     caught, which keeps the explicit-types channel separate from the catch-all empty-list channel.
+     *
+     * @param array<int, string>|null $forTypes
+     */
+    private static function shouldSkip(?array $forTypes, ?string $packageType): bool
+    {
+        if ($forTypes === null) {
+            return false;
+        }
+
+        if ($forTypes === []) {
+            return true;
+        }
+
+        return in_array($packageType, $forTypes, true);
     }
 }

--- a/src/Config/PackageType.php
+++ b/src/Config/PackageType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symplify\MonorepoBuilder\Config;
+
+/**
+ * Composer package type filter values, derived from the official Composer schema.
+ *
+ * @see https://getcomposer.org/doc/04-schema.md#type
+ *
+ * Cases cover the four schema-documented package types. For ecosystem types defined by
+ * composer/installers (e.g., `wordpress-plugin`, `drupal-module`, `symfony-bundle`) and
+ * for user-defined types, callers may pass plain strings alongside enum cases — see
+ * `MBConfig::disableAutoloadMerge()` for the accepted union shape.
+ */
+enum PackageType: string
+{
+    case Library = 'library';
+    case Project = 'project';
+    case Metapackage = 'metapackage';
+    case ComposerPlugin = 'composer-plugin';
+}


### PR DESCRIPTION
## Summary

Replaces the binary `MBConfig::disableAutoloadMerge()` (introduced in #114) with a parameterized form that lets users independently control which composer.json autoload sections to skip and which package types to skip them for. The previous zero-argument form continues to work and emits an `E_USER_DEPRECATED` notice.

## Why

The binary `disableAutoloadMerge()` couples two orthogonal axes — sections (`autoload` vs `autoload-dev`) and package-type filter (all vs subset) — into a single on/off switch. Users in real monorepos hit three limitations:

1. **No way to skip only `autoload`** — useful when libraries are symlinked into root `vendor/` via `path` repositories (Composer auto-registers their PSR-4 from `vendor/composer/autoload_psr4.php`, so root-merge duplicates entries).
2. **No way to keep `autoload-dev` merging** while skipping `autoload` — Composer treats `autoload-dev` as root-only, so libs' test classes must be folded into the root `composer.json` for root-level `phpunit` discovery.
3. **No way to filter by package type** — mixed monorepos with `type: library` packages and `type: project` apps need different handling per type.

## What changed

- New `Symplify\MonorepoBuilder\Config\AutoloadSection` enum (cases `Autoload`, `AutoloadDev`).
- New `Symplify\MonorepoBuilder\Config\PackageType` enum covering the four [Composer schema](https://getcomposer.org/doc/04-schema.md#type) types (`Library`, `Project`, `Metapackage`, `ComposerPlugin`).
- `MBConfig::disableAutoloadMerge(array \$sections, array \$forTypes)` — both required when called with arguments. \$sections is a non-empty list of `AutoloadSection` cases. \$forTypes is a list of `PackageType` enum cases AND/OR plain strings (escape hatch for `composer/installers` types like `wordpress-plugin`, `drupal-module`, `symfony-bundle`, and user-defined types).
- New `MBConfig::shouldSkipAutoload(?string \$packageType): bool` and `shouldSkipAutoloadDev(?string \$packageType): bool` query methods consumed by `AutoloadComposerKeyMerger` and `AutoloadDevComposerKeyMerger` respectively. The autoload-dev merger now consults config symmetrically (the previous binary check only short-circuited there because both mergers shared the same flag).
- Repeated calls to `disableAutoloadMerge()` follow last-call-wins semantics PER section. Calls touching different sections compose; calls on the same section override.

## Back-compat

- `disableAutoloadMerge()` (zero-arg) — still works, emits `E_USER_DEPRECATED`, mapped to skipping both sections for all packages (the previous semantic).
- `MBConfig::isAutoloadMergeDisabled()` — still works, marked `@deprecated` in PHPDoc, returns `true` only when both sections are configured to skip merging for all packages (matches the legacy semantic).
- Calling with only one argument (e.g. `disableAutoloadMerge([Autoload])`) throws `InvalidArgumentException` — guides existing callers toward updating their config rather than silently doing the wrong thing.

No release-version commitment is required; existing user configs continue to function unchanged.

## Test plan

- 12 new test methods in `packages-tests/Merge/ComposerKeyMerger/AutoloadComposerKeyMerger/AutoloadComposerKeyMergerTest.php` covering the full 2-axis matrix (autoload-only / autoload-dev-only / both x all-packages / specific-types) plus PackageType-vs-string-fallback / mixed-call / last-call-wins / independent-sections-compose / legacy-zero-arg / deprecation-trigger / one-arg-throws / `isAutoloadMergeDisabled` semantics.
- Full PHPUnit suite passes: 82 tests, 323 assertions, 2 pre-existing skips.
- `composer check-cs` (ECS) passes.
- `composer phpstan` passes.
- `composer check-rector` clean.

## README

The `## Configuration` section was reorganized into parallel `Commands` and `Configuration` blocks with a dedicated decision-tree subsection \"Skip autoload merging for selected packages\" covering three real-world scenarios (default monorepo, mixed monorepo with symlinked libs, custom merge), an explicit \"Why autoload-dev is independent\" note linking to the Composer schema docs, and a migration note for existing zero-arg callers.