### PR TITLE
Fix uninitialized typed $container error on Symfony Console 8.1

### DIFF
--- a/src/Console/MonorepoBuilderApplication.php
+++ b/src/Console/MonorepoBuilderApplication.php
@@ -14,7 +14,7 @@ final class MonorepoBuilderApplication extends Application
      */
     public function __construct(array $commands)
     {
-        $this->addCommands($commands);
         parent::__construct();
+        $this->addCommands($commands);
     }
 }


### PR DESCRIPTION
## Summary

`MonorepoBuilderApplication::__construct` calls `$this->addCommands($commands)` **before** `parent::__construct()`. Symfony Console 8.1 promoted `$container` to a typed constructor-promoted property on `Application`, and the `addCommand()` → `init()` → `registerContainerServices()` path reads `$this->container`. Reading an uninitialized typed property fatals:

```
Typed property Symfony\Component\Console\Application::$container must not be accessed before initialization
```

Calling `parent::__construct()` first resolves it. Always-correct pattern; the old order only happened to work because the parent didn't access a typed property in that path before 8.1.

Fixes #118.

